### PR TITLE
fix: correctly build the path of the cache dir

### DIFF
--- a/src/data/ArtistsToolkitData.ts
+++ b/src/data/ArtistsToolkitData.ts
@@ -20,6 +20,7 @@ import {
     writeTextFile
 } from "@tauri-apps/plugin-fs";
 import fm from "front-matter";
+import { path } from "@tauri-apps/api";
 export async function addScrapbookFile(filePath) {
     console.log("adding item", filePath);
     const contentFileType = getContentFileType(filePath);
@@ -57,7 +58,7 @@ export async function scanScrapbook() {
             for (const entry of entries.filter(
                 (f) => !f.name.startsWith(".")
             )) {
-                const filePath = settings.scrapbookLocation + "/" + entry.name;
+                const filePath = await path.join(settings.scrapbookLocation, entry.name);
                 console.log("adding item", filePath);
                 const contentFileType = getContentFileType(filePath);
                 console.log("type", contentFileType);
@@ -138,7 +139,7 @@ export async function loadSongProjectsForArtist(artistName: string) {
     if (!songbookLocation) return;
 
     try {
-        const dirContents = await readDir(songbookLocation + "/" + artistName);
+        const dirContents = await readDir(await path.join(songbookLocation, artistName));
         const songFolders = dirContents.filter((item) => item.isDirectory);
         const songs: string[] = songFolders.map((folder) => folder.name);
         songs.sort();

--- a/src/data/Cacher.ts
+++ b/src/data/Cacher.ts
@@ -6,6 +6,7 @@
 // } from "@tauri-apps/plugin-fs";
 // import { appDataDir } from "@tauri-apps/api/path";
 
+import { path } from "@tauri-apps/api";
 import { appDataDir } from "@tauri-apps/api/path";
 import { remove } from "@tauri-apps/plugin-fs";
 
@@ -107,7 +108,7 @@ export const CACHE_DIR =
 export const deleteCacheDirectory = async () => {
     try {
         const dataDir = await appDataDir();
-        await remove(`${dataDir}${CACHE_DIR}`, {
+        await remove(await path.join(dataDir, CACHE_DIR), {
             recursive: true
         });
     } catch (error) {

--- a/src/data/LibraryImporter.ts
+++ b/src/data/LibraryImporter.ts
@@ -27,6 +27,7 @@ import {
     songsJustAdded,
     userSettings
 } from "./store";
+import { path } from "@tauri-apps/api";
 const appWindow = getCurrentWebviewWindow();
 
 let addedSongs: Song[] = [];
@@ -357,7 +358,7 @@ export async function getArtistProfileImage(
                 filename.name.includes("profile")
             ) {
                 foundResult = {
-                    artworkSrc: convertFileSrc(folder + "/" + filename.name),
+                    artworkSrc: convertFileSrc(await path.join(folder, filename.name)),
                     artworkFormat: format,
                     artworkFilenameMatch: filename.name
                 };

--- a/src/data/M3UUtils.ts
+++ b/src/data/M3UUtils.ts
@@ -13,6 +13,7 @@ import { db } from "./db";
 import { selectedPlaylistFile, userPlaylists, userSettings } from "./store";
 import { moveArrayElement } from "../utils/ArrayUtils";
 import { invoke } from "@tauri-apps/api/core";
+import { path } from "@tauri-apps/api";
 
 interface M3UTrack {
     duration: number; // Duration in seconds, -1 if unknown
@@ -81,7 +82,7 @@ export async function scanPlaylists() {
         if (entry.isFile && entry.name.endsWith(".m3u")) {
             m3uFiles.push({
                 title: entry.name.split(".m3u")[0],
-                path: playlistsLocation + "/" + entry.name
+                path: await path.join(playlistsLocation, entry.name)
             });
         }
     }
@@ -126,7 +127,7 @@ export async function addSongsToPlaylists(
 export async function createNewPlaylistFile(title: string) {
     await writePlaylist(
         {
-            path: get(userSettings).playlistsLocation + "/" + title + ".m3u",
+            path: await path.join(get(userSettings).playlistsLocation, `${title}.m3u`),
             title
         },
         []

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -340,7 +340,7 @@ async function init() {
     const playlistsDir = await audioDir();
     if (!fileSettings.playlistsLocation) {
         fileSettings.playlistsLocation =
-            playlistsDir.concat("/Musicat Playlists");
+            path.join(playlistsDir, "Musicat Playlists");
     }
 
     // Get user settings

--- a/src/lib/data/LibraryEnrichers.ts
+++ b/src/lib/data/LibraryEnrichers.ts
@@ -6,6 +6,7 @@ import type { Album, Song } from "../../App";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import md5 from "md5";
 import { addOriginCountryStatus } from "../../data/store";
+import { path } from "@tauri-apps/api";
 
 export async function findCountryByArtist(artistName) {
     if (!artistName?.length) return null;
@@ -114,7 +115,7 @@ export async function fetchAlbumArt(
             console.log("imageData");
 
             if (imageBody) {
-                const filePath = album.path + "/cover." + imageExtension;
+                const filePath = await path.join(album.path,  `cover.${imageExtension}`);
                 console.log("filepath", filePath);
                 // Write a binary file to the `$APPDATA/avatar.png` path
                 await writeFile(filePath, imageBody);

--- a/src/window/EventListener.ts
+++ b/src/window/EventListener.ts
@@ -17,6 +17,7 @@ import { CACHE_DIR, deleteCacheDirectory } from "../data/Cacher";
 import { open } from "@tauri-apps/plugin-shell";
 import { appConfigDir, appDataDir, dataDir } from "@tauri-apps/api/path";
 import { openTauriImportDialog } from "../data/LibraryImporter";
+import { path } from "@tauri-apps/api";
 const appWindow = getCurrentWebviewWindow()
 
 export function startMenuListener() {
@@ -73,7 +74,7 @@ export function startMenuListener() {
                 try {
                     const dir = await appDataDir();
                     console.log("dir", dir);
-                    open(`${dir}${CACHE_DIR}`);
+                    open(await path.join(dir, CACHE_DIR));
                 } catch (err) {
                     console.error(err);
                 }


### PR DESCRIPTION
This PR is fixing the path of the cache dir.
On my system, the `appDataDir()` doesn't finish with a path separator.