### PR TITLE
fix: update csp & add capability for external drives

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
                 "scope": ["**"],
                 "enable": true
             },
-            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src ipc: http://ipc.localhost"
+            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src ipc: http://ipc.localhost asset: https://asset.localhost"
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
                 "scope": ["**"],
                 "enable": true
             },
-            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src ipc: http://ipc.localhost asset: https://asset.localhost"
+            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src https://www.wikidata.org https://en.wikipedia.org https://upload.wikimedia.org https://dbpedia.org *.archive.org https://archive.org ipc: http://ipc.localhost asset: https://asset.localhost"
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,7 +58,18 @@
         "withGlobalTauri": true,
         "windows": [],
         "security": {
-            "capabilities": ["main-capability"],
+            "capabilities": [
+                "main-capability",
+                {
+                    "identifier": "write-external-drives",
+                    "description": "Capability to be able to write artworks on external drives",
+                    "windows": ["*"],
+                    "permissions": [{
+                        "identifier": "fs:allow-write-file",
+                        "allow": ["**"]
+                    }]
+                }
+            ],
             "assetProtocol": {
                 "scope": ["**"],
                 "enable": true

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -51,7 +51,7 @@
         "windows": [],
         "security": {
             "capabilities": ["main-capability"],
-            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src ipc: http://ipc.localhost"
+            "csp": "default-src 'self' https://api.iconify.design  https://api.simplesvg.com https://api.unisvg.com https://www.wikidata.org https://en.wikipedia.org https://api.openai.com https://api.genius.com *.archive.org https://archive.org asset: https://asset.localhost stream: http://stream.localhost; img-src 'self' https://archive.org asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' https://*.archive.org archive.org; connect-src https://www.wikidata.org https://en.wikipedia.org https://upload.wikimedia.org https://dbpedia.org *.archive.org https://archive.org ipc: http://ipc.localhost asset: https://asset.localhost"
         }
     }
 }


### PR DESCRIPTION
This PR adds the CSP rule so that the tags can be read when musicat is built in release mode.
It doesn't change anything in dev mode.

I was getting the error:
```
[Error] Refused to connect to asset://localhost/ because it does not appear in the connect-src directive of the Content Security Policy.
```