### PR TITLE
fix: don't play a song when search has no results

### DIFF
--- a/src/lib/library/CanvasLibrary.svelte
+++ b/src/lib/library/CanvasLibrary.svelte
@@ -1006,13 +1006,18 @@
 
     $: {
         if (
-            songs?.length &&
             $query.query?.length &&
             $popupOpen !== "track-info"
         ) {
-            highlightSong(songs[0], 0, false, true);
+            if (songs?.length === 0) {
+                songsHighlighted = [];
+            }
+            else {
+                highlightSong(songs[0], 0, false, true);
+            }
         }
     }
+
     export let songsHighlighted: Song[] = [];
     export let onSongsHighlighted = null;
 

--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -121,6 +121,11 @@ class AudioPlayer {
 
         playlist.subscribe(async (playlist) => {
             this.playlist = playlist;
+
+            if (playlist.length === 0) {
+                return;
+            }
+
             const shuffleEnabled = get(isShuffleEnabled);
             const shuffledPlylist = get(shuffledPlaylist);
             let newCurrentSongIdx = 0;


### PR DESCRIPTION
This PR avoids to play a song when the search has no results and pressing the <kbd>enter</kbd> key.