### PR TITLE
fix: resize queue when waveform is displayed

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -628,7 +628,7 @@
         }
 
         .queue {
-            grid-row: 2/6;
+            grid-row: 2/5;
             grid-column: 2;
             overflow: hidden;
             height: 100%;


### PR DESCRIPTION
This PR fixes the queue when the waveform is shown.

Here the bug:
![Screenshot 2024-12-19 at 02 59 36](https://github.com/user-attachments/assets/a285cd45-fd45-41f3-90d4-f9848e92c4f0)
