### PR TITLE
fix: jumpy album

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -639,7 +639,7 @@
                 overflow: hidden;
                 /* border-bottom: 0.7px solid #ffffff36; */
                 border-radius: 5px;
-                margin: 0px 7.5px 0 0;
+                margin: 0px 8px 0 0;
                 display: grid;
                 grid-template-rows: 1fr auto;
                 gap: 5px;
@@ -659,7 +659,7 @@
                 overflow: hidden;
                 border-bottom: 0.7px solid #ffffff36;
                 border-radius: 5px;
-                margin: 0px 7.5px 0 0;
+                margin: 0px 8px 0 0;
             }
 
             .close-wiki-prompt {

--- a/src/lib/views/TopBar.svelte
+++ b/src/lib/views/TopBar.svelte
@@ -373,7 +373,7 @@
             max-width: 600px;
             margin: 0 5px;
             z-index: 12;
-            top: -7.5px;
+            top: -8px;
             .elapsed-time {
                 width: max-content;
                 white-space: nowrap;


### PR DESCRIPTION
This PR fixes the jumpy album's covers (a 1px flicker) when:
- the queue is opened
- moving the cursor over the covers

The bug is due to the rounding which is not always the same between frames.