### PR TITLE
fix: resolve issues in the internet archive explorer

### DIFF
--- a/src/App.d.ts
+++ b/src/App.d.ts
@@ -419,7 +419,7 @@ interface IAItem {
     date?: number;
     performer?: string;
     writer?: string;
-    original: IAFile;
+    originals: IAFile[];
 }
 
 interface AudioDevice {

--- a/src/data/InternetArchiveAPI.ts
+++ b/src/data/InternetArchiveAPI.ts
@@ -2,10 +2,9 @@ import type { IACollection, IAFile, IAItem } from "../App";
 
 export async function getIACollections(page: number) {
     const response = await fetch(
-        `https://archive.org/advancedsearch.php?fl%5B%5D=identifier&q=collection%3Aaudio_music%20AND%20mediatype%3A(collection)&fl%5B%5D=collection_size&fl%5B%5D=collection_files_count&fl%5B%5D=description&fl%5B%5D=title&rows=20&mediatype=collection&page=${page}&output=json&sort=week%20desc`
+        `https://archive.org/advancedsearch.php?q=collection%3Aaudio_music%20AND%20mediatype%3A%28collection%29&fl%5B%5D=identifier&fl%5B%5D=collection_size&fl%5B%5D=collection_files_count&fl%5B%5D=description&fl%5B%5D=title&rows=20&page=${page}&output=json&sort=week%20desc`
     );
     const responseJson = await response.json();
-    console.log("response", responseJson);
     const collection: IACollection[] = responseJson.response.docs.map((d) => ({
         id: d.identifier,
         title: d.title,
@@ -18,10 +17,9 @@ export async function getIACollections(page: number) {
 
 export async function getIACollection(collectionId, page) {
     const response = await fetch(
-        `https://archive.org/advancedsearch.php?q=collection%3A(${collectionId})%20AND%20mediatype%3A(audio)&fl%5B%5D=identifier&fl%5B%5D=title&sort%5B%5D&sort%5B%5D&sort%5B%5D&rows=50&page=${page}&output=json`
+        `https://archive.org/advancedsearch.php?q=collection%3A%28${collectionId}%29%20AND%20mediatype%3A(audio)&fl%5B%5D=identifier&fl%5B%5D=title&sort%5B%5D&sort%5B%5D&sort%5B%5D&rows=50&page=${page}&output=json`
     );
     const responseJson = await response.json();
-    console.log("response", responseJson);
     const collection: IAItem[] = responseJson.response.docs.map((d) => ({
         id: d.identifier,
         title: d.title
@@ -30,9 +28,10 @@ export async function getIACollection(collectionId, page) {
 }
 
 export async function getIAItem(itemId) {
+    console.log(`https://archive.org/metadata/${itemId}`)
     const response = await fetch(`https://archive.org/metadata/${itemId}`);
     const responseJson = await response.json();
-    const original = findOriginal(responseJson);
+    const originals = findOriginals(responseJson);
 
     const item: IAItem = {
         id: itemId,
@@ -40,49 +39,49 @@ export async function getIAItem(itemId) {
         server1: responseJson.d1,
         server2: responseJson.d2,
         dir: responseJson.dir,
-        original: original,
+        originals,
         // Match against types in IAFormat type
         files: responseJson.files
-            .filter((f) => isValidFormat(f) && f.source !== "original")
+            .filter((f) => !f.private && isValidFormat(f) && f.source !== "original")
             .map((f) => mapFile(f, responseJson)),
         date: responseJson.metadata?.date,
         performer: responseJson.roles?.performer,
         writer: responseJson.roles?.writer
     };
+    console.log(JSON.stringify(item, null, '\t'))
     return item;
 }
 
-function isValidFormat(file: any) {
-    return mapFormat(file)?.match(/(mp3|flac)/i);
+function isValidFormat(file) {
+    return /flac|mp3/i.test(file.format);
 }
 
-function findOriginal(response): IAFile {
+function findOriginals(response): IAFile[] {
+    const result = [];
+
     for (let file of response.files) {
-        if (file.source === "original" && mapFormat(file) === "mp3") {
-            return mapFile(file, response);
+        if (!file.private && file.source === "original" && isValidFormat(file)) {
+            result.push(mapFile(file, response));
         }
     }
 
-    for (let file of response.files) {
-        if (file.source === "original" && mapFormat(file) === "flac") {
-            return mapFile(file, response);
-        }
-    }
-    return undefined;
+    return result;
+}
+
+function joinUrlParts(...parts: string[]): string {
+    return parts.map(part => part.replace(/(^\/+|\/+$)/g, '')).join('/');
 }
 
 function mapFile(f, responseJson) {
     let supportedFormat = mapFormat(f);
     f.format = supportedFormat ? supportedFormat : undefined;
     f.duration = timestampToSeconds(f["length"]);
-    console.log("duration", f.duration);
-    f.previewSrc = `https://${responseJson.d1}/${responseJson.dir}/${f.name}`;
+    f.previewSrc = `https://${joinUrlParts(responseJson.d1, responseJson.dir, f.name)}`;
     f.itemId = responseJson.metadata.identifier;
     return f;
 }
 
 function timestampToSeconds(timestamp) {
-    console.log("timestamp", timestamp);
     if (!timestamp || timestamp?.length === 0) return undefined;
     // Split the timestamp into minutes and seconds
     const parts = timestamp.split(":");
@@ -106,9 +105,9 @@ function timestampToSeconds(timestamp) {
 }
 
 function mapFormat(file) {
-    if (file.format?.match(/(mp3)/i)) {
+    if (file.format?.match(/mp3/i)) {
         return "mp3";
-    } else if (file.format?.match(/(flac)/i)) {
+    } else if (file.format?.match(/flac/i)) {
         return "flac";
     }
     return undefined;

--- a/src/lib/internet-archive/IAFileBlock.svelte
+++ b/src/lib/internet-archive/IAFileBlock.svelte
@@ -8,6 +8,7 @@
     } from "../player/WebAudioPlayer";
     import Icon from "../ui/Icon.svelte";
     import { currentThemeObject } from "../../theming/store";
+    import { path } from "@tauri-apps/api";
 
     export let file: IAFile;
     let downloadProgress = null;
@@ -16,7 +17,7 @@
         console.log("download");
         downloadProgress = 0;
         try {
-            file.downloadLocation = `${$userSettings.downloadLocation}/${file.title ?? file.name}`;
+            file.downloadLocation = await path.join($userSettings.downloadLocation, await path.basename(file.title ?? file.name));
             // Append extension if doesn't exist
             if (!file.downloadLocation.match(/\/[^\/]+\.[^\/]+$/)) {
                 file.downloadLocation += `.${file.format}`;

--- a/src/lib/views/InternetArchiveView.svelte
+++ b/src/lib/views/InternetArchiveView.svelte
@@ -212,10 +212,12 @@
                 <div class="header">
                     {#if $iaSelectedCollection}
                         <div class="top-row">
-                            <img
-                                src="https://archive.org/services/img/{$iaSelectedCollection.id}"
-                            />
-                            <h2>{$iaSelectedCollection.title}</h2>
+                            <a href="https://archive.org/details/{$iaSelectedCollection.id}" target="_blank">
+                                <img
+                                    src="https://archive.org/services/img/{$iaSelectedCollection.id}"
+                                />
+                                <h2>{$iaSelectedCollection.title}</h2>
+                            </a>
                         </div>
                         {#if $iaSelectedCollection.description}
                             <p class="description">
@@ -282,7 +284,9 @@
             <div class="column-audio">
                 {#if isLoadingItem}
                     <div class="header">
-                        <h2>{$iaSelectedItem?.title}</h2>
+                        <a href="https://archive.org/details/{$iaSelectedItem?.id}" target="_blank">
+                            <h2>{$iaSelectedItem?.title}</h2>
+                        </a>
                         <p>Loading</p>
                         <div class="loading">
                             <LoadingSpinner />
@@ -290,11 +294,18 @@
                     </div>
                 {:else if $iaSelectedItem}
                     <div class="header">
-                        <h2>{$iaSelectedItem?.title}</h2>
+                        <a href="https://archive.org/details/{$iaSelectedItem?.id}" target="_blank">
+                            <h2>{$iaSelectedItem?.title}</h2>
+                        </a>
                     </div>
-                    <h3>Original</h3>
-                    {#if $iaSelectedItem.original}
-                        <IaFileBlock file={$iaSelectedItem.original} />
+                    {#if $iaSelectedItem.originals}
+                        <h3>Original</h3>
+
+                        <div class="files">
+                            {#each $iaSelectedItem.originals as file}
+                                <IaFileBlock {file} />
+                            {/each}
+                        </div>
                     {/if}
                     {#if $iaSelectedItem.files}
                         <h3>Files</h3>
@@ -587,7 +598,7 @@
                 border-bottom: 0.7px solid
                     color-mix(in srgb, var(--inverse) 30%, transparent);
                 z-index: 2;
-                .top-row {
+                .top-row a {
                     display: flex;
                     width: 100%;
 


### PR DESCRIPTION
This PR fixes several issues:
- fix url so it can list the collections
- a record can have several originals (https://archive.org/details/lp_sings_heinrich-rehkemper)
- the songs can be private and so can't be listened (https://archive.org/details/lp_nuits-dt-shhrazade_hector-berlioz-maurice-ravel-hildegard-beh)
- `previewSrc` was built with an extra `/` so it wasn't able to be listened
- when downloading, if the target file was on an another drive than the temp file, the `persist` function was failing

A new feature:
- links on the title of the collection and song to open the archive.org page in a browser