### PR TITLE
fix: open links into browser with correct url

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-range",
+ "kuchiki",
  "lofty",
  "log",
  "log4rs",
@@ -2377,6 +2378,20 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.10.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
@@ -2870,6 +2885,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kuchiki"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+dependencies = [
+ "cssparser 0.27.2",
+ "html5ever 0.25.2",
+ "matches",
+ "selectors 0.22.0",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3083,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+dependencies = [
+ "log",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ url = "2.5.2"
 log4rs = "1.3.0"
 urlencoding = "2.1.3"
 trash = "5.1.1"
+kuchiki = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"

--- a/src-tauri/src/scrape.rs
+++ b/src-tauri/src/scrape.rs
@@ -3,6 +3,10 @@ use std::error::Error;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
 
+use kuchiki::traits::*;
+use kuchiki::parse_html;
+use url::Url;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GetHTMLRequest {
     url: String,
@@ -13,11 +17,47 @@ pub struct GetHTMLResponse {
     html: Option<String>,
 }
 
+fn edit_anchors(html: String, prefix: String) -> String {
+    let document = parse_html().one(html);
+    let prefix_url = Url::parse(prefix.as_str()).unwrap();
+    
+    for css_match in document.select("a").unwrap() {
+        let as_node = css_match.as_node();
+        if let Some(element) = as_node.as_element() {
+            let mut attrs = element.attributes.borrow_mut();
+            
+            // add target="_blank"
+            attrs.insert("target".to_string(), "_blank".to_string());
+            
+            // add "https://en.wikipedia.org" to the links
+            if let Some(href) = attrs.get("href") {
+                let mut new_url = prefix_url.join(href).unwrap();
+
+                if prefix_url.host_str() != new_url.host_str() {
+                    new_url.set_scheme(prefix_url.scheme()).unwrap();
+                    new_url.set_host(prefix_url.host_str()).unwrap();
+
+                    if let Some(port) = prefix_url.port() {
+                        new_url.set_port(Some(port)).unwrap();
+                    }
+                }
+
+                attrs.insert("href".to_string(), new_url.to_string());
+            }
+        }
+    }
+
+    let mut bytes = vec![];
+    document.serialize(&mut bytes).unwrap();
+
+    String::from_utf8(bytes).unwrap()
+}
+
 #[tauri::command]
 pub async fn get_wikipedia(event: GetHTMLRequest) -> GetHTMLResponse {
     let html = fetch_wikipedia(event.url.as_str()).await;
     return GetHTMLResponse {
-        html: html.map_or(None, |l| Some(l)),
+        html: html.map_or(None, |l| Some(edit_anchors(l, event.url))),
     };
 }
 


### PR DESCRIPTION
This PR opens the links from the wikipedia html into a browser by:
- adding target="_blank"
- adding the prefix "https://en.wikipedia.org" (based on url of the article)