### PR TITLE
feat: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.svg]
+insert_final_newline = false


### PR DESCRIPTION
This PR adds the `.editorconfig` which allows to maintain coding styles across different editors.
reference: https://editorconfig.org/
It's really useful.

I've configured based on your usage.