### PR TITLE
fix: reset keeps waveform and oscilloscope

### DIFF
--- a/src/lib/player/Oscilloscope.svelte
+++ b/src/lib/player/Oscilloscope.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
     import { onMount } from "svelte";
     import { current, isFullScreenVisualiser } from "../../data/store";
-    import audioPlayer from "./AudioPlayer";
-    import Icon from "../ui/Icon.svelte";
     import { AudioVisualiser } from "./AudioVisualiser";
     import { isIAPlaying } from "./WebAudioPlayer";
     import { WebAudioVisualiser } from "./WebAudioVisualiser";
 
+    export let width;
+    export let show = true;
+
+    let analyser: AudioVisualiser | WebAudioVisualiser;
     let canvas: HTMLCanvasElement;
     let container: HTMLDivElement;
-    export let width;
     let height = 30;
-    let analyser: AudioVisualiser | WebAudioVisualiser;
-    export let show = true;
     let isMounted = false;
+    let song = null;
 
     $: if (analyser) {
         if (show) {
@@ -33,6 +33,10 @@
         analyser = new AudioVisualiser(canvas);
     }
 
+    $: if (isMounted && $current.song && $current.song.path !== song?.path) {
+        song = $current.song;
+    }
+
     onMount(() => {
         width = container.clientWidth;
         isMounted = true;
@@ -45,12 +49,7 @@
     class:full-screen={$isFullScreenVisualiser}
     class:mini={!$isFullScreenVisualiser}
 >
-    <canvas
-        bind:this={canvas}
-        class:hidden={$current.song === null}
-        {width}
-        {height}
-    />
+    <canvas bind:this={canvas} class:hidden={song === null} {width} {height} />
 </div>
 
 <style lang="scss">

--- a/src/lib/views/AlbumsView.svelte
+++ b/src/lib/views/AlbumsView.svelte
@@ -125,7 +125,8 @@
 
     $: if (
         container &&
-        $current.song?.album.toLowerCase() !== currentAlbum?.title.toLowerCase()
+        $current.song &&
+        $current.song.album.toLowerCase() !== currentAlbum?.title.toLowerCase()
     ) {
         if (updatePlayingAlbum()) {
             onScroll();


### PR DESCRIPTION
This PR keeps the waveform and the oscilloscope running if a song is playing and the queue is reseted.

Currently, when reseting the queue, the waveform throws an error because the condition `$current.song?.path !== song?.path` is `true` when there is no current song.
(`$current.song?.path` => `null`, `null !== song?.path` => `true`)