### PR TITLE
fix: resize wiki when waveform is displayed

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -645,7 +645,7 @@
         }
 
         .wiki {
-            grid-row: 3/6;
+            grid-row: 3/5;
             grid-column: 5;
             overflow-y: hidden;
             height: 100%;


### PR DESCRIPTION
Same as #52 but for the wiki panel...