### PR TITLE
fix: don't set current song to null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
                 "mpg123-decoder": "^1.0.0",
                 "openai": "^4.22.0",
                 "postcss": "^8.4.16",
+                "prettier": "^3.4.2",
                 "sass": "^1.54.5",
                 "svelte": "^4.2.8",
                 "svelte-check": "^3.6.2",
@@ -2951,6 +2952,22 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
+        },
+        "node_modules/prettier": {
+            "version": "3.4.2",
+            "resolved": "http://localhost:4873/prettier/-/prettier-3.4.2.tgz",
+            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
         },
         "node_modules/prism-svelte": {
             "version": "0.4.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "mpg123-decoder": "^1.0.0",
         "openai": "^4.22.0",
         "postcss": "^8.4.16",
+        "prettier": "^3.4.2",
         "sass": "^1.54.5",
         "svelte": "^4.2.8",
         "svelte-check": "^3.6.2",

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -87,9 +87,11 @@ export const current: Writable<PlayingSong> = writable(
     },
 );
 current.subscribe(({ song, index, position }) => {
-    const data = song
-        ? { song: song.id, index, position }
-        : { song: null, index: 0, position: 0 };
+    // don't store song that isn't in the queue
+    const data =
+        song && index >= 0
+            ? { song: song.id, index, position }
+            : { song: null, index: 0, position: 0 };
 
     localStorage.setItem("current", JSON.stringify(data));
 });

--- a/src/data/storeHelper.ts
+++ b/src/data/storeHelper.ts
@@ -43,25 +43,26 @@ export function setQueue(
             queue.set(newQueue);
             queueDuration.set(newDuration);
         } else {
-            current.set({ song: null, index: 0, position: 0 });
+            const $current = get(current);
+            if ($current.song) {
+                // the current song isn't in the queue, set index to -1
+                current.set({ ...$current, index: -1 });
+            }
             queue.set(newQueue);
             queueDuration.set(newDuration);
         }
     } else if (nextSong) {
         const nextIndex = get(queue).indexOf(nextSong);
 
-        if (nextIndex !== -1) {
-            current.set({ song: nextSong, index: nextIndex, position: 0 });
-            queue.set(newQueue);
-        } else {
-            current.set({ song: null, index: 0, position: 0 });
-            queue.set(newQueue);
-            queueDuration.set(newDuration);
-
-            nextSong = null;
-        }
+        current.set({ song: nextSong, index: nextIndex, position: 0 });
+        queue.set(newQueue);
+        queueDuration.set(newDuration);
     } else {
-        current.set({ song: null, index: 0, position: 0 });
+        const $current = get(current);
+        if ($current.song) {
+            // the current song isn't in the queue, set index to -1
+            current.set({ ...$current, index: -1 });
+        }
         queue.set(newQueue);
         queueDuration.set(newDuration);
     }

--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -13,7 +13,7 @@ import {
     seekTime,
     shuffledQueue,
     userSettings,
-    volume
+    volume,
 } from "../../data/store";
 import { shuffleArray } from "../../utils/ArrayUtils";
 
@@ -74,7 +74,7 @@ class AudioPlayer {
     stats = {
         packetDropCounter: 0,
         packetReceivedCounter: 0,
-        totalPacketCounter: 0
+        totalPacketCounter: 0,
     };
     flowControlSendInterval;
 
@@ -105,7 +105,7 @@ class AudioPlayer {
                 const id = this.currentSong?.id;
                 if (id) {
                     newCurrentSongIdx = this.queue.findIndex(
-                        (s) => s.id === id
+                        (s) => s.id === id,
                     );
                 } else {
                     newCurrentSongIdx = 0;
@@ -149,7 +149,7 @@ class AudioPlayer {
                     const id = this.currentSong?.id;
                     if (id) {
                         newCurrentSongIdx = this.queue.findIndex(
-                            (s) => s.id === id
+                            (s) => s.id === id,
                         );
                     } else {
                         newCurrentSongIdx = 0;
@@ -164,7 +164,7 @@ class AudioPlayer {
                 const id = this.currentSong?.id;
                 if (id) {
                     newCurrentSongIdx = this.queue.findIndex(
-                        (s) => s.id === id
+                        (s) => s.id === id,
                     );
                 } else {
                     newCurrentSongIdx = 0;
@@ -176,7 +176,7 @@ class AudioPlayer {
                 const id = this.currentSong?.id;
                 if (id) {
                     newCurrentSongIdx = this.queue.findIndex(
-                        (s) => s.id === id
+                        (s) => s.id === id,
                     );
                 } else {
                     newCurrentSongIdx = 0;
@@ -190,7 +190,7 @@ class AudioPlayer {
             console.log(
                 "playlist: currentsongindex",
                 this.currentSongIdx,
-                this.currentSong
+                this.currentSong,
             );
 
             this.setNextUpSong();
@@ -210,8 +210,8 @@ class AudioPlayer {
         volume.subscribe(async (vol) => {
             await invoke("volume_control", {
                 event: {
-                    volume: vol * 0.75
-                }
+                    volume: vol * 0.75,
+                },
             });
             localStorage.setItem("volume", String(vol));
         });
@@ -223,7 +223,7 @@ class AudioPlayer {
             current.set({
                 song: this.currentSong,
                 index: this.currentSongIdx,
-                position: 0
+                position: 0,
             });
 
             this.setNextUpSong();
@@ -277,7 +277,7 @@ class AudioPlayer {
         current.set({
             song: this.currentSong,
             index: this.currentSongIdx,
-            position
+            position,
         });
         isShuffleEnabled.set(true);
     }
@@ -301,8 +301,11 @@ class AudioPlayer {
     }
 
     playCurrent(seek: number = 0) {
-        const { song, position } = get(current);
-        this.playSong(song, seek || position);
+        if (this.currentSong) {
+            this.playSong(this.currentSong, seek);
+        } else {
+            this.playSong(this.queue[this.currentSongIdx], seek);
+        }
     }
 
     hasNext() {
@@ -341,10 +344,10 @@ class AudioPlayer {
                               sizes: this.artworkSrc.size
                                   ? `${this.artworkSrc.size.width}x${this.artworkSrc.size.height}`
                                   : "128x128",
-                              type: this.artworkSrc.format
-                          }
+                              type: this.artworkSrc.format,
+                          },
                       ]
-                    : []
+                    : [],
             });
         }
     }
@@ -356,7 +359,7 @@ class AudioPlayer {
                 () => {
                     console.log("action handler play");
                     this.play(true);
-                }
+                },
             ],
             [
                 "pause",
@@ -364,25 +367,25 @@ class AudioPlayer {
                     console.log("action handler pause");
                     // Pause active playback
                     this.pause();
-                }
+                },
             ],
             [
                 "previoustrack",
                 () => {
                     /* ... */
-                }
+                },
             ],
             [
                 "nexttrack",
                 () => {
                     /* ... */
-                }
+                },
             ],
             [
                 "stop",
                 () => {
                     /* ... */
-                }
+                },
             ],
             ["seekbackward", null],
             ["seekforward", null],
@@ -390,8 +393,8 @@ class AudioPlayer {
                 "seekto",
                 (details) => {
                     /* ... */
-                }
-            ]
+                },
+            ],
         ];
 
         for (const [action, handler] of actionHandlers) {
@@ -399,7 +402,7 @@ class AudioPlayer {
                 navigator.mediaSession.setActionHandler(action, handler);
             } catch (error) {
                 console.log(
-                    `The media session action "${action}" is not supported yet.`
+                    `The media session action "${action}" is not supported yet.`,
                 );
             }
         }
@@ -422,8 +425,8 @@ class AudioPlayer {
                     path: nextSong.path,
                     seek: 0,
                     file_info: nextSong.fileInfo,
-                    volume: get(volume)
-                }
+                    volume: get(volume),
+                },
             });
         } else {
             nextUpSong.set(null);
@@ -433,15 +436,15 @@ class AudioPlayer {
                     path: null,
                     seek: 0,
                     file_info: null,
-                    volume: get(volume)
-                }
+                    volume: get(volume),
+                },
             });
         }
     }
 
     async incrementPlayCounter(song: Song) {
         await db.songs.update(song, {
-            playCount: song.playCount ? song.playCount + 1 : 1
+            playCount: song.playCount ? song.playCount + 1 : 1,
         });
     }
 
@@ -461,7 +464,7 @@ class AudioPlayer {
                 playerTime.set(position);
                 console.log(
                     "audioplayer::datachannel::",
-                    this.webRTCReceiver.dataChannel?.readyState
+                    this.webRTCReceiver.dataChannel?.readyState,
                 );
 
                 if (
@@ -482,8 +485,8 @@ class AudioPlayer {
                         path: this.currentSong.path,
                         seek: position,
                         file_info: this.currentSong.fileInfo,
-                        volume: get(volume)
-                    }
+                        volume: get(volume),
+                    },
                 });
                 this.incrementPlayCounter(song);
             }
@@ -492,7 +495,7 @@ class AudioPlayer {
                 index !== null
                     ? index
                     : this.queue.findIndex(
-                          (s) => s.id === this.currentSong?.id
+                          (s) => s.id === this.currentSong?.id,
                       );
             if (newCurrentSongIdx === -1) {
                 newCurrentSongIdx = 0;
@@ -525,8 +528,8 @@ class AudioPlayer {
                 paths: paths,
                 recursive: false,
                 process_albums: false,
-                is_async: false
-            }
+                is_async: false,
+            },
         });
         console.log("scan_paths response", response);
         if (response.songs) {
@@ -541,8 +544,8 @@ class AudioPlayer {
         if (isResume) {
             await invoke("decode_control", {
                 event: {
-                    decoding_active: true
-                }
+                    decoding_active: true,
+                },
             });
         }
 
@@ -552,8 +555,8 @@ class AudioPlayer {
     async pause() {
         invoke("decode_control", {
             event: {
-                decoding_active: false
-            }
+                decoding_active: false,
+            },
         });
         this.onPause();
     }


### PR DESCRIPTION
This PR fixes the issues of #81 and #83 as discussed in #81.

In `package.json`, I've added the dependency `prettier` to force the version used by the vscode plugin.
No sure why, on my machine, it was using the version `2.8.8` (which seems to remove the trailing commas by default) instead of the a `3.x` which add the trailing commas (what you want based on your comment in https://github.com/basharovV/musicat/commit/82c341a5de0c2c0ba27a52e36bc41256a4ba10de)
It was correctly adding them before...