### PR TITLE
enhance: improve track info popup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2996,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bc4717ff10833a623b009e9254ae8667c7a59edc3cfb01c37aeeef4b6d54a7"
+checksum = "e50322c6dc739042a87fde4a5a16c80c9ed94fb0f04912f9660d409167da37fe"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -3724,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "ogg_pager"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b0bef808533c5890ab77279538212efdbbbd9aa4ef1ccdfcfbf77a42f7e6fa"
+checksum = "e034c10fb5c1c012c1b327b85df89fb0ef98ae66ec28af30f0d1eed804a40c19"
 dependencies = [
  "byteorder",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri = { version = "2.0.0-rc", features = [
 ] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-lofty = { version = "0.21.1" }
+lofty = "0.22.0"
 base64 = "0.22.1"
 filetime = "0.2.25"
 chksum-md5 = "0.0.0"

--- a/src-tauri/src/metadata.rs
+++ b/src-tauri/src/metadata.rs
@@ -847,7 +847,6 @@ fn write_metadata_track(v: &WriteMetatadaEvent) -> Result<(), anyhow::Error> {
                 if item.id == "METADATA_BLOCK_PICTURE" {
                     // Ignore picture, set by artwork_file_to_set
                 } else if item.id == "year" {
-                    info!("year");
                     if item.value.is_null() {
                         tag.remove_year();
                     } else {

--- a/src-tauri/src/metadata.rs
+++ b/src-tauri/src/metadata.rs
@@ -891,7 +891,12 @@ fn write_metadata_track(v: &WriteMetatadaEvent) -> Result<(), anyhow::Error> {
                             if tag_key.eq_ignore_ascii_case("TRCK") {
                                 item_key = ItemKey::TrackNumber;
                             }
-                            to_write.insert(TagItem::new(item_key, item_value));
+
+                            let item = TagItem::new(item_key, item_value);
+
+                            if !to_write.insert(item.clone()) && tag_type_evt == "iTunes" {
+                                to_write.insert_unchecked(item);
+                            }
                         }
                     }
                 }
@@ -902,7 +907,8 @@ fn write_metadata_track(v: &WriteMetatadaEvent) -> Result<(), anyhow::Error> {
                 while to_write.pictures().len() > 0 {
                     to_write.remove_picture(0);
                 }
-            } // Set artwork if provided
+            }
+            // Set artwork if provided
             else if !v.artwork_file.is_empty() {
                 let picture_file = File::options()
                     .read(true)

--- a/src/App.d.ts
+++ b/src/App.d.ts
@@ -52,6 +52,9 @@ interface Song {
     genre: string[];
     composer: string[];
     trackNumber: number;
+    trackTotal: number;
+    discNumber: number;
+    discTotal: number;
     duration: string;
     metadata: MetadataEntry[];
     fileInfo: FileInfo;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -48,7 +48,7 @@
     import SmartPlaylistHeader from "./lib/library/SmartPlaylistHeader.svelte";
     import TagCloud from "./lib/library/TagCloud.svelte";
     import ToDeleteHeader from "./lib/library/ToDeleteHeader.svelte";
-    import TrackInfoPopup from "./lib/library/TrackInfoPopup.svelte";
+    import TrackInfoPopup from "./lib/info/TrackInfoPopup.svelte";
     import audioPlayer from "./lib/player/AudioPlayer";
     import InfoPopup from "./lib/settings/InfoPopup.svelte";
     import SettingsPopup from "./lib/settings/SettingsPopup.svelte";

--- a/src/data/LabelMap.ts
+++ b/src/data/LabelMap.ts
@@ -27,8 +27,6 @@ interface TagFieldMap {
     compilation?: string;
     discNumber?: string;
     encodingTool?: string;
-    gapless?: string;
-    normalization?: string;
 }
 
 const genericToVorbisMap: TagFieldMap = {
@@ -48,7 +46,7 @@ const genericToVorbisMap: TagFieldMap = {
     license: "LICENSE",
     location: "LOCATION",
     isrc: "ISRC",
-    bpm: "BPM"
+    bpm: "BPM",
 };
 
 const vorbisToGenericMap = inverse(genericToVorbisMap);
@@ -64,7 +62,7 @@ const genericToId3v1Map: TagFieldMap = {
     album: "album",
     genre: "genre",
     date: "year",
-    trackNumber: "track"
+    trackNumber: "track",
 };
 
 const id3v1ToGenericMap = inverse(genericToId3v1Map);
@@ -88,7 +86,7 @@ const genericToId3v22Map: TagFieldMap = {
     copyright: "TCR",
     publisher: "TPB",
     isrc: "TRC",
-    bpm: "TBP"
+    bpm: "TBP",
 };
 
 const id3v22ToGenericMap = inverse(genericToId3v22Map);
@@ -112,7 +110,7 @@ const genericToId3v23Map: TagFieldMap = {
     copyright: "TCOP",
     publisher: "TPUB",
     isrc: "TSRC",
-    bpm: "TBPM"
+    bpm: "TBPM",
 };
 
 const id3v23ToGenericMap = inverse(genericToId3v23Map);
@@ -136,7 +134,7 @@ const genericToId3v24Map: TagFieldMap = {
     copyright: "TCOP",
     publisher: "TPUB",
     isrc: "TSRC",
-    bpm: "TBPM"
+    bpm: "TBPM",
 };
 
 const id3v24ToGenericMap = inverse(genericToId3v24Map);
@@ -158,15 +156,13 @@ const genericToiTunesMap: TagFieldMap = {
     trackNumber: "trkn",
     copyright: "cprt",
     encodingTool: "©too",
-    gapless: "----:com.apple.iTunes:iTunSMPB",
-    normalization: "----:com.apple.iTunes:iTunNORM"
 };
 
 const iTunesToGenericMap = inverse(genericToiTunesMap);
 
 function getMapForTagType(
     tagType: TagType,
-    fromGeneric: boolean = true
+    fromGeneric: boolean = true,
 ): object | null {
     switch (tagType) {
         case "vorbis":
@@ -194,7 +190,7 @@ function getMapForTagType(
 const codecToTagTypeMap = {
     FLAC: "Vorbis",
     MPEG: "ID3v2.4",
-    "MPEG 1 Layer 3": "ID3v2.4"
+    "MPEG 1 Layer 3": "ID3v2.4",
 };
 
 function getTagTypeFromCodec(codec) {

--- a/src/data/LabelMap.ts
+++ b/src/data/LabelMap.ts
@@ -39,7 +39,7 @@ interface TagFieldMap {
     composer?: string;
     performer?: string;
     genre: string;
-    date: string;
+    year: string;
     copyright?: string;
     publisher?: string;
     trackNumber: string;
@@ -60,7 +60,7 @@ const genericToVorbisMap: TagFieldMap = {
     albumArtist: "ALBUMARTIST",
     composer: "COMPOSER",
     genre: "GENRE",
-    date: "DATE",
+    year: "DATE",
     compilation: "COMPILATION",
     trackNumber: "TRACKNUMBER",
     trackTotal: ["TRACKTOTAL", "TOTALTRACKS"],
@@ -86,7 +86,7 @@ const genericToId3v1Map: TagFieldMap = {
     artist: "artist",
     album: "album",
     genre: "genre",
-    date: "year",
+    year: "year",
     trackNumber: "track",
 };
 
@@ -104,7 +104,7 @@ const genericToId3v22Map: TagFieldMap = {
     albumArtist: "TP2",
     composer: "TCM",
     genre: "TCO",
-    date: "TYE",
+    year: "TYE",
     compilation: "TCP",
     trackNumber: "TRK",
     trackTotal: ["TRK"],
@@ -130,7 +130,7 @@ const genericToId3v23Map: TagFieldMap = {
     albumArtist: "TPE2",
     composer: "TCOM",
     genre: "TCON",
-    date: "TDAT",
+    year: "TDAT",
     compilation: "TCMP",
     trackNumber: "TRCK",
     trackTotal: ["TRCK"],
@@ -156,7 +156,7 @@ const genericToId3v24Map: TagFieldMap = {
     albumArtist: "TPE2",
     composer: "TCOM",
     genre: "TCON",
-    date: "TDRC",
+    year: "TDRC",
     compilation: "TCMP",
     trackNumber: "TRCK",
     trackTotal: ["TRCK"],
@@ -183,7 +183,8 @@ const genericToiTunesMap: TagFieldMap = {
     albumArtist: "aART",
     composer: "©wrt",
     genre: "gnre",
-    date: "©day",
+    year: "©day",
+    compilation: "cpil",
     trackNumber: "trkn",
     trackTotal: ["trkn"],
     discNumber: "disk",

--- a/src/data/LabelMap.ts
+++ b/src/data/LabelMap.ts
@@ -1,9 +1,32 @@
 import type { TagType } from "src/App";
 
 function inverse(obj) {
-    var retobj = {};
-    for (var key in obj) {
-        retobj[obj[key]] = key;
+    const retobj = {};
+    for (const key in obj) {
+        const value = obj[key];
+        if (Array.isArray(value)) {
+            for (const val of value) {
+                if (retobj[val]) {
+                    if (Array.isArray(retobj[val])) {
+                        retobj[val].push(key);
+                    } else {
+                        retobj[val] = [retobj[val], key];
+                    }
+                } else {
+                    retobj[val] = key;
+                }
+            }
+        } else {
+            if (retobj[value]) {
+                if (Array.isArray(retobj[value])) {
+                    retobj[value].push(key);
+                } else {
+                    retobj[value] = [retobj[value], key];
+                }
+            } else {
+                retobj[value] = key;
+            }
+        }
     }
     return retobj;
 }
@@ -20,12 +43,13 @@ interface TagFieldMap {
     copyright?: string;
     publisher?: string;
     trackNumber: string;
+    trackTotal?: string[];
     license?: string;
-    location?: string;
     isrc?: string;
     bpm?: string;
     compilation?: string;
     discNumber?: string;
+    discTotal?: string[];
     encodingTool?: string;
 }
 
@@ -37,14 +61,15 @@ const genericToVorbisMap: TagFieldMap = {
     composer: "COMPOSER",
     genre: "GENRE",
     date: "DATE",
-    trackNumber: "TRACKNUMBER",
     compilation: "COMPILATION",
+    trackNumber: "TRACKNUMBER",
+    trackTotal: ["TRACKTOTAL", "TOTALTRACKS"],
     discNumber: "DISCNUMBER",
+    discTotal: ["DISCTOTAL", "TOTALDISCS"],
     copyright: "COPYRIGHT",
     publisher: "PUBLISHER",
     performer: "PERFORMER",
     license: "LICENSE",
-    location: "LOCATION",
     isrc: "ISRC",
     bpm: "BPM",
 };
@@ -80,9 +105,11 @@ const genericToId3v22Map: TagFieldMap = {
     composer: "TCM",
     genre: "TCO",
     date: "TYE",
-    trackNumber: "TRK",
     compilation: "TCP",
+    trackNumber: "TRK",
+    trackTotal: ["TRK"],
     discNumber: "TPA",
+    discTotal: ["TPA"],
     copyright: "TCR",
     publisher: "TPB",
     isrc: "TRC",
@@ -104,9 +131,11 @@ const genericToId3v23Map: TagFieldMap = {
     composer: "TCOM",
     genre: "TCON",
     date: "TDAT",
-    trackNumber: "TRCK",
     compilation: "TCMP",
+    trackNumber: "TRCK",
+    trackTotal: ["TRCK"],
     discNumber: "TPOS",
+    discTotal: ["TPOS"],
     copyright: "TCOP",
     publisher: "TPUB",
     isrc: "TSRC",
@@ -128,9 +157,11 @@ const genericToId3v24Map: TagFieldMap = {
     composer: "TCOM",
     genre: "TCON",
     date: "TDRC",
-    trackNumber: "TRCK",
     compilation: "TCMP",
+    trackNumber: "TRCK",
+    trackTotal: ["TRCK"],
     discNumber: "TPOS",
+    discTotal: ["TPOS"],
     copyright: "TCOP",
     publisher: "TPUB",
     isrc: "TSRC",
@@ -154,6 +185,9 @@ const genericToiTunesMap: TagFieldMap = {
     genre: "gnre",
     date: "©day",
     trackNumber: "trkn",
+    trackTotal: ["trkn"],
+    discNumber: "disk",
+    discTotal: ["disk"],
     copyright: "cprt",
     encodingTool: "©too",
 };

--- a/src/data/LibraryUtils.ts
+++ b/src/data/LibraryUtils.ts
@@ -62,8 +62,10 @@ export async function readMappedMetadataFromSong(
     const mappedMetadata: MetadataEntry[] = [];
 
     if (map) {
-        for (const { id, value } of metadata?.native[tagType]) {
-            if (typeof value !== "string") {
+        for (let { id, value } of metadata?.native[tagType]) {
+            if (typeof value === "number") {
+                value = `${value}`;
+            } else if (typeof value !== "string") {
                 continue;
             }
 

--- a/src/lib/info/MetadataSection.svelte
+++ b/src/lib/info/MetadataSection.svelte
@@ -6,6 +6,7 @@
     import LL from "../../i18n/i18n-svelte";
     import {
         current,
+        isPlaying,
         lastWrittenSongs,
         playerTime,
         rightClickedTrack,
@@ -413,21 +414,24 @@
             position: "top-right",
         });
 
-        $lastWrittenSongs = $rightClickedTrack
-            ? [$rightClickedTrack]
-            : $rightClickedTracks;
-
-        // If we changed the artwork tag, this offsets the audio data in the file,
-        // so we need to reload the song and seek to the current position
-        // (will cause audible gap)
         const writtenTracks = $rightClickedTrack
             ? [$rightClickedTrack]
             : $rightClickedTracks;
-        if (
-            hasArtworkToSet() &&
-            writtenTracks.map((t) => t.id).includes($current.song.id)
-        ) {
-            audioPlayer.setSeek(get(playerTime));
+
+        $lastWrittenSongs = writtenTracks;
+
+        const id = $current.song?.id;
+
+        if (id && writtenTracks.some((t) => t.id == id)) {
+            // Update sidebar infos
+            $current = $current;
+
+            // If we changed the artwork tag, this offsets the audio data in the file,
+            // so we need to reload the song and seek to the current position
+            // (will cause audible gap)
+            if (hasArtworkToSet()) {
+                audioPlayer.setSeek(get(playerTime));
+            }
         }
 
         await reset();

--- a/src/lib/info/MetadataSection.svelte
+++ b/src/lib/info/MetadataSection.svelte
@@ -1,0 +1,768 @@
+<svelte:options accessors={true} />
+
+<script lang="ts">
+    import { fly } from "svelte/transition";
+    import Icon from "../ui/Icon.svelte";
+    import LL from "../../i18n/i18n-svelte";
+    import {
+        current,
+        lastWrittenSongs,
+        playerTime,
+        rightClickedTrack,
+        rightClickedTracks,
+    } from "../../data/store";
+    import type {
+        Album,
+        MetadataEntry,
+        Song,
+        TagType,
+        ToImport,
+    } from "src/App";
+    import { invoke } from "@tauri-apps/api/core";
+    import { readMappedMetadataFromSong } from "../../data/LibraryUtils";
+    import toast from "svelte-french-toast";
+    import { db } from "../../data/db";
+    import { get } from "svelte/store";
+    import audioPlayer from "../player/AudioPlayer";
+    import { optionalTippy } from "../ui/TippyAction";
+    import Input from "../ui/Input.svelte";
+    import {
+        ENCODINGS,
+        decodeLegacy,
+        encodeUtf8,
+    } from "../../utils/EncodingUtils";
+    import ButtonWithIcon from "../ui/ButtonWithIcon.svelte";
+    import { cloneDeep, isEqual, uniqBy } from "lodash-es";
+    import { getMapForTagType } from "../../data/LabelMap";
+    import { onMount } from "svelte";
+
+    type ValidationErrors = "err:invalid-chars" | "err:null-chars";
+    type ValidationWarnings = "warn:custom-tag" | "warn:cyrillic-encoding";
+
+    type Validation = {
+        [key: string]: {
+            errors: ValidationErrors[];
+            warnings: ValidationWarnings[];
+        };
+    };
+
+    const ALBUM_FIELDS = [
+        "album",
+        "albumArtist",
+        "artist",
+        "date",
+        "genre",
+        "compilation",
+    ];
+
+    const VALIDATION_STRINGS = {
+        "err:invalid-chars":
+            "Invalid characters in metadata tag (hidden/unicode characters?)",
+        "err:null-chars": "Hidden null characer",
+        "warn:custom-tag":
+            "Custom tags can't be parsed. If a custom tag can be a standard tag, use that instead.",
+    };
+
+    export let completeEvent: (event) => {};
+    export let hasChanges = false;
+    export let data: { mappedMetadata: MetadataEntry[]; tagType: TagType } = {
+        mappedMetadata: [],
+        tagType: null,
+    };
+    export let hasArtworkToSet: () => boolean;
+    export let reset: () => void;
+    export let rollbackArtwork: () => void;
+
+    /**
+     * Some tags have a \u0000 character dangling at the end.
+     * This prevents the metadata from being read properly, so we can
+     * show a prompt to fix this with the user's permission.
+     */
+    let containsError: ValidationErrors = null;
+    let distinctArtists;
+    let firstMatch: string = null;
+    let isUnsupportedFormat: boolean;
+    let metadataFromFile: MetadataEntry[] = [];
+    // Encodings
+    let selectedEncoding = "placeholder";
+
+    $: artistInput =
+        data?.mappedMetadata?.find((m) => m.genericId === "compilation")
+            ?.value === "1" ||
+        data?.mappedMetadata?.find((m) => m.genericId === "albumArtist")?.value
+            ? ""
+            : (data?.mappedMetadata?.find((m) => m.genericId === "artist")
+                  ?.value ?? "");
+
+    /**
+     * A map of tag id <-> errors that apply to this tag
+     */
+    $: errors =
+        data?.mappedMetadata?.reduce((errors: Validation, currentTag) => {
+            containsError = null;
+            if (!errors[currentTag.id]) {
+                errors[currentTag.id] = {
+                    errors: [],
+                    warnings: [],
+                };
+            }
+            if (!errors[currentTag.id].errors) {
+                errors[currentTag.id].errors = [];
+            }
+            if (!errors[currentTag.id].warnings) {
+                errors[currentTag.id].warnings = [];
+            }
+
+            // Invalid characters - null unicode
+            if (currentTag.id.match(/[\u0000]+/g)) {
+                errors[currentTag.id].errors.push("err:null-chars");
+                containsError = "err:null-chars"; // We want to display a prompt
+            } // Invalid characters
+            else if (!currentTag.id.match(/^[a-zA-Z0-9©_:\-\.]+$/)) {
+                errors[currentTag.id].errors.push("err:invalid-chars");
+            }
+
+            // Custom tag - warning
+            if (currentTag.id.match(/^(TXXX:)/g)) {
+                errors[currentTag.id].warnings.push("warn:custom-tag");
+            }
+
+            // TODO Detect encodings
+            // Tried jschardet but it didn't give good results.
+            // Maybe scrap this entirely?
+
+            // const windows_encodings = ["windows-1251"];
+            // const encoding = jschardet.detect(currentTag.value || "", {
+            //     detectEncodings: ENCODINGS,
+            // });
+            // console.log('encoding detect', encoding);
+            // { encoding: "UTF-8", confidence: 0.9690625 }
+
+            // if (
+            //     windows_encodings.includes(encoding.encoding) &&
+            //     encoding.confidence > 0.5
+            // ) {
+            //     errors[currentTag.id].warnings.push("warn:cyrillic-encoding");
+            // }
+
+            console.log("hasErrors", hasError("err:null-chars"));
+            return errors;
+        }, {}) ?? {};
+
+    $: firstMatchRemainder = firstMatch?.startsWith(artistInput)
+        ? firstMatch.substring(artistInput.length, firstMatch.length)
+        : "";
+    $: {
+        console.log(firstMatchRemainder);
+    }
+
+    $: hasChanges = !isEqual(data?.mappedMetadata, metadataFromFile);
+
+    function addDefaults(entry: MetadataEntry[], format: TagType) {
+        // Map eg. 'TITLE' (FLAC/Vorbis) -> title (Musicat generic identifier)
+        const map = getMapForTagType(format, false);
+        // Add empty default fields
+        const defaults: MetadataEntry[] = [];
+        const others: MetadataEntry[] = [];
+        console.log("map", map);
+        if (!map) return { defaults, others };
+        for (const field of Object.entries(map)) {
+            // Check if this default field already exists in the file
+            const existingField = entry?.find((m) => field[1] === m.genericId);
+
+            defaults.push({
+                id: field[0],
+                genericId: field[1],
+                value: existingField ? existingField.value : null,
+            });
+        }
+
+        for (const field of entry) {
+            const inDefaults = defaults.find(
+                (t) => t.genericId === field.genericId,
+            );
+            if (!inDefaults) {
+                others.push({
+                    id: field.id,
+                    genericId: field.genericId,
+                    value: field.value,
+                });
+            }
+        }
+        return { defaults, others };
+    }
+
+    async function fixEncoding() {
+        for (let item of data?.mappedMetadata) {
+            if (!item?.value) continue;
+            const decoded = decodeLegacy(item.value, selectedEncoding);
+            const encoded = new TextDecoder().decode(encodeUtf8(decoded));
+            console.log("transformed: ", encoded);
+            item.value = encoded;
+            data = data;
+        }
+    }
+
+    function hasError(errorType: ValidationErrors): boolean {
+        return (
+            errors &&
+            Object.values(errors).filter((err) =>
+                err.errors.includes(errorType),
+            ).length > 0
+        );
+    }
+
+    function mergeDefault(
+        metadata: MetadataEntry[],
+        format: TagType,
+    ): MetadataEntry[] {
+        if (
+            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.codec ===
+            "WAV"
+        ) {
+            isUnsupportedFormat = true;
+            return []; // UNSUPPORTED FORMAT, for now...
+        }
+
+        console.log("adding defaults", metadata, format);
+        if (!format) return [];
+
+        isUnsupportedFormat = false;
+        const cloned = cloneDeep(metadata);
+        const { defaults, others } = addDefaults(cloned, format);
+        return uniqBy(
+            [...defaults, ...others.sort((a, b) => a.id.localeCompare(b.id))],
+            "id",
+        );
+    }
+
+    function onArtistAutocompleteSelected() {
+        if (firstMatch?.length) {
+            console.log("firstMatch", firstMatch);
+            console.log("artistInput", artistInput);
+            const artistField = data?.mappedMetadata?.find(
+                (m) => m.genericId === "artist",
+            );
+            if (artistField) {
+                artistField.value = firstMatch;
+                artistInput = firstMatch;
+            }
+            data = data;
+            firstMatch = null;
+        }
+    }
+
+    async function onArtistUpdated(value) {
+        console.log("artist updated");
+        artistInput = value;
+        const artistField = data?.mappedMetadata?.find(
+            (m) => m.genericId === "artist",
+        );
+        if (artistField) {
+            artistField.value = artistInput;
+        }
+        data = data;
+        let matched = [];
+        const artist = value;
+        if (artist && artist.trim().length > 0) {
+            if (distinctArtists === undefined) {
+                distinctArtists = await db.songs.orderBy("artist").uniqueKeys();
+            }
+            distinctArtists.forEach((a) => {
+                if (a.toLowerCase().startsWith(artist.toLowerCase())) {
+                    matched.push(a);
+                }
+            });
+
+            firstMatch = matched.length && matched[0] ? matched[0] : null;
+        } else {
+            firstMatch = null;
+        }
+    }
+
+    function onTagLabelClick(tag: MetadataEntry) {
+        // Double-clicking on title populates the title from the filename
+        if (tag.genericId === "title") {
+            // Strip file extension from filename if any
+            const filename = $rightClickedTrack.file;
+            const extension = filename.split(".").pop();
+            const filenameWithoutExtension = filename.replace(
+                "." + extension,
+                "",
+            );
+            tag.value = filenameWithoutExtension;
+            data = data;
+        }
+    }
+
+    async function reImportAlbum(album: Album) {
+        const existingAlbum = await db.albums.get(album.id);
+        if (existingAlbum) {
+            existingAlbum.tracksIds = [
+                ...existingAlbum.tracksIds,
+                ...album.tracksIds,
+            ];
+            await db.albums.put(existingAlbum);
+        }
+    }
+
+    async function reImportTracks(songs: Song[]) {
+        await db.songs.bulkPut(songs);
+    }
+
+    export async function resetMetadata() {
+        containsError = null;
+        const { mappedMetadata, tagType } = await readMappedMetadataFromSong(
+            $rightClickedTrack || $rightClickedTracks[0],
+        );
+        data = {
+            mappedMetadata: mergeDefault(mappedMetadata, tagType),
+            tagType,
+        };
+        metadataFromFile = cloneDeep(data.mappedMetadata);
+        hasChanges = !isEqual(data?.mappedMetadata, metadataFromFile);
+        console.log("metadata", data);
+    }
+
+    function stripNonAsciiChars() {
+        data.mappedMetadata = data?.mappedMetadata.map((entry) => ({
+            ...entry,
+            id: entry.id?.replace(/(\u0000)/g, "") ?? entry.id,
+        }));
+        console.log("stripped ascii: ", data);
+        writeMetadata();
+    }
+
+    /**
+     * Send an event to the backend to write the new metadata, overwriting any existing tags.
+     */
+    export async function writeMetadata() {
+        let toImport: ToImport;
+        if ($rightClickedTrack) {
+            const toWrite = data?.mappedMetadata
+                .filter((m) => m.value !== null)
+                .map((t) => ({ id: t.id, value: t.value }));
+            console.log("Writing: ", toWrite);
+
+            const event = {
+                tracks: [
+                    completeEvent({
+                        song_id: $rightClickedTrack.id,
+                        metadata: toWrite,
+                        tag_type: data.tagType,
+                        file_path: $rightClickedTrack.path,
+                    }),
+                ],
+            };
+            // console.log("event: ", event);
+
+            toImport = await invoke<ToImport>("write_metadatas", { event });
+        } else if ($rightClickedTracks?.length) {
+            console.log("Writing album");
+            toImport = await invoke<ToImport>("write_metadatas", {
+                event: {
+                    tracks: await Promise.all(
+                        $rightClickedTracks.map(async (track) => {
+                            const fileMetadata =
+                                await readMappedMetadataFromSong(track);
+                            return completeEvent({
+                                song_id: track.id,
+                                metadata: [
+                                    ...fileMetadata?.mappedMetadata,
+                                    ...data?.mappedMetadata
+                                        .filter(
+                                            (m) =>
+                                                m.value !== null &&
+                                                ALBUM_FIELDS.includes(
+                                                    m.genericId,
+                                                ),
+                                        )
+                                        .map((t) => ({
+                                            id: t.id,
+                                            value: t.value,
+                                        })),
+                                ],
+                                tag_type: fileMetadata.tagType,
+                                file_path: track.path,
+                            });
+                        }),
+                    ),
+                },
+            });
+        }
+        console.log($rightClickedTrack || $rightClickedTracks[0]);
+        console.log(toImport);
+        if (toImport) {
+            if (toImport.error) {
+                // Show error
+                toast.error(toImport.error);
+                // Roll back to current artwork
+                rollbackArtwork();
+            } else {
+                await reImportTracks(toImport.songs);
+            }
+        }
+
+        if (toImport.albums.length) {
+            for (const album of toImport.albums) {
+                await reImportAlbum(album);
+            }
+        }
+
+        toast.success("Successfully written metadata!", {
+            position: "top-right",
+        });
+
+        $lastWrittenSongs = $rightClickedTrack
+            ? [$rightClickedTrack]
+            : $rightClickedTracks;
+
+        // If we changed the artwork tag, this offsets the audio data in the file,
+        // so we need to reload the song and seek to the current position
+        // (will cause audible gap)
+        const writtenTracks = $rightClickedTrack
+            ? [$rightClickedTrack]
+            : $rightClickedTracks;
+        if (
+            hasArtworkToSet() &&
+            writtenTracks.map((t) => t.id).includes($current.song.id)
+        ) {
+            audioPlayer.playCurrent(get(playerTime));
+        }
+
+        await reset();
+    }
+
+    onMount(async () => {
+        resetMetadata();
+    });
+</script>
+
+<section class="metadata-section boxed">
+    <h5 class="section-title">
+        <Icon icon="fe:music" size={30} />{$LL.trackInfo.metadata()}
+    </h5>
+    {#if $rightClickedTrack || $rightClickedTracks[0]}
+        {#if isUnsupportedFormat}
+            <p>
+                {$LL.trackInfo.unsupportedFormat()}
+            </p>
+        {:else}
+            {#if containsError === "err:null-chars"}
+                <div
+                    transition:fly={{ y: -20, duration: 100 }}
+                    class="error-prompt"
+                >
+                    <Icon icon="ant-design:warning-outlined" />
+                    <p>
+                        {$LL.trackInfo.errors.nullChars()}
+                    </p>
+                    <button on:click={stripNonAsciiChars}
+                        >{$LL.trackInfo.fix()}</button
+                    >
+                </div>
+            {/if}
+            <form>
+                {#each data?.mappedMetadata?.filter((m) => $rightClickedTrack || ($rightClickedTracks.length && ALBUM_FIELDS.includes(m.genericId))) as tag, idx}
+                    {#if tag.genericId === "artist"}
+                        <div class="tag">
+                            <p class="label">
+                                {$LL.trackInfo.artist()}
+                            </p>
+                            <div class="line" />
+                            <div
+                                class="artist-input"
+                                use:optionalTippy={{
+                                    content: $LL.input.enterHintTooltip(),
+                                    placement: "bottom",
+                                    show:
+                                        firstMatch !== null &&
+                                        firstMatch.toLowerCase() !==
+                                            artistInput?.toLowerCase() &&
+                                        artistInput?.length > 0,
+                                    showOnCreate: true,
+                                    trigger: "manual",
+                                }}
+                            >
+                                <Input
+                                    small
+                                    value={artistInput}
+                                    autoCompleteValue={firstMatch}
+                                    onChange={onArtistUpdated}
+                                    onEnterPressed={onArtistAutocompleteSelected}
+                                    tabBehavesAsEnter
+                                    fullWidth
+                                />
+                            </div>
+                        </div>
+                    {:else}
+                        <div
+                            use:optionalTippy={{
+                                content: errors[tag.id]?.errors
+                                    .map((e) => VALIDATION_STRINGS[e])
+                                    .concat(
+                                        errors[tag.id]?.warnings.map(
+                                            (e) => VALIDATION_STRINGS[e],
+                                        ),
+                                    )
+                                    .join(","),
+                                placement: "bottom",
+                                theme: "error",
+                                show:
+                                    errors[tag.id]?.errors.length > 0 ||
+                                    errors[tag.id]?.warnings.length > 0,
+                            }}
+                            class="tag
+                                {errors[tag.id]?.warnings.length > 0
+                                ? 'validation-warning'
+                                : ''}
+                                    {errors[tag.id]?.errors.length > 0
+                                ? 'validation-error'
+                                : ''}"
+                        >
+                            <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                            <p
+                                class="label"
+                                class:unmapped={tag.genericId === undefined}
+                                data-tag-id={tag.genericId || tag.id}
+                                on:click={() => onTagLabelClick(tag)}
+                                use:optionalTippy={{
+                                    content:
+                                        $LL.trackInfo.setTitleFromFileNameHint(),
+                                    show: tag.genericId === "title",
+                                    placement: "bottom",
+                                }}
+                            >
+                                {tag.genericId ? tag.genericId : tag.id}
+                            </p>
+                            <div class="line" />
+                            <Input bind:value={tag.value} fullWidth small />
+                        </div>
+                    {/if}
+                {/each}
+            </form>
+            {#if data?.mappedMetadata?.length}
+                <div class="tools">
+                    <h5 class="section-title">
+                        <Icon icon="ri:tools-fill" />{$LL.trackInfo.tools()}
+                    </h5>
+                    <div class="tool">
+                        <div class="description">
+                            <p>
+                                {$LL.trackInfo.fixLegacyEncodings.title()}
+                            </p>
+                            <small
+                                >{$LL.trackInfo.fixLegacyEncodings.body()}</small
+                            >
+                        </div>
+                        <select bind:value={selectedEncoding}>
+                            <option value="placeholder"
+                                >{$LL.trackInfo.fixLegacyEncodings.hint()}</option
+                            >
+                            {#each ENCODINGS as encoding}
+                                <option
+                                    value={encoding}
+                                    class="encoding"
+                                    on:click={() => {
+                                        selectedEncoding = encoding;
+                                    }}
+                                >
+                                    <p>{encoding}</p>
+                                </option>
+                            {/each}
+                        </select>
+                        <ButtonWithIcon
+                            text={$LL.trackInfo.fix()}
+                            theme="transparent"
+                            onClick={fixEncoding}
+                            disabled={selectedEncoding === "placeholder"}
+                        />
+                    </div>
+                </div>
+            {/if}
+        {/if}
+    {:else}
+        <p>{$LL.trackInfo.noMetadata()}</p>
+    {/if}
+</section>
+
+<style lang="scss">
+    .metadata-section {
+        margin-top: 2em;
+        border-radius: 5px;
+        position: relative;
+        padding: 2em 1em;
+        color: var(--text);
+        position: relative;
+        width: 100%;
+        border: 1px solid
+            color-mix(in srgb, var(--background) 70%, var(--inverse));
+        background-color: color-mix(
+            in srgb,
+            var(--overlay-bg) 80%,
+            var(--inverse)
+        );
+
+        font-family:
+            system-ui,
+            -apple-system,
+            Avenir,
+            Helvetica,
+            Arial,
+            sans-serif;
+
+        .section-title {
+            color: var(--popup-track-metadata-title);
+            border: 1px solid
+                rgb(from var(--popup-track-metadata-title) r g b / 0.08);
+        }
+
+        > p {
+            opacity: 0.5;
+        }
+    }
+
+    form {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        column-gap: 3em;
+
+        @media only screen and (max-width: 700px) {
+            grid-template-columns: 1fr;
+            .tag {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                &:nth-child(odd) {
+                    justify-content: center;
+                }
+                &:nth-child(even) {
+                    justify-content: center;
+                }
+            }
+        }
+
+        @media only screen and (min-width: 701px) {
+            .tag {
+                display: flex;
+                align-items: center;
+                &:nth-child(odd) {
+                    justify-content: right;
+                }
+                &:nth-child(even) {
+                    justify-content: left;
+                    flex-direction: row-reverse;
+                }
+            }
+        }
+
+        .tag {
+            display: flex;
+            align-items: center;
+            position: relative;
+            margin: 1px 0;
+            > .label {
+                width: fit-content;
+                margin: 0;
+                font-size: 13px;
+                font-weight: 500;
+                color: var(--text);
+                font-family: monospace;
+                user-select: none;
+                cursor: default;
+                white-space: nowrap;
+                text-transform: uppercase;
+                border: 1px solid transparent;
+
+                &.unmapped {
+                    opacity: 0.5;
+                }
+                &[data-tag-id="title"] {
+                    &:hover {
+                        border: 1px solid
+                            color-mix(
+                                in srgb,
+                                var(--background) 60%,
+                                var(--inverse)
+                            );
+                        cursor: pointer;
+                    }
+                }
+            }
+
+            .line {
+                height: 1px;
+                background-color: color-mix(
+                    in srgb,
+                    var(--background) 60%,
+                    var(--inverse)
+                );
+                width: 40px;
+            }
+
+            &.validation-error {
+                border: 1px solid var(--popup-track-metadata-validation-error);
+            }
+
+            &.validation-warning {
+                border: 1px solid var(--popup-track-metadata-validation-warning);
+            }
+        }
+
+        .artist-input {
+            /* overflow: hidden; */
+        }
+    }
+
+    .tools {
+        border: 1px solid rgb(from var(--inverse) r g b / 0.08);
+        padding: 2em;
+        margin: 2em;
+        position: relative;
+
+        .section-title {
+            color: rgb(from var(--popup-track-section-title-text) r g b / 0.85);
+            border: transparent;
+        }
+
+        .tool {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 5px;
+            color: var(--text);
+            * {
+                color: var(--text);
+            }
+
+            .description {
+                text-align: left;
+                p {
+                    margin: 0;
+                }
+                small {
+                    opacity: 0.7;
+                    line-height: 0.5em;
+                }
+            }
+
+            select {
+                font-size: 20px;
+                padding: 0.2em 1em 0.3em 1em;
+            }
+        }
+    }
+
+    .error-prompt {
+        padding: 0.2em;
+        border-radius: 8px;
+        margin: 1em;
+        background-color: var(--popup-track-metadata-prompt-error);
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        p {
+            margin: 0;
+        }
+    }
+</style>

--- a/src/lib/info/MetadataSection.svelte
+++ b/src/lib/info/MetadataSection.svelte
@@ -427,7 +427,7 @@
             hasArtworkToSet() &&
             writtenTracks.map((t) => t.id).includes($current.song.id)
         ) {
-            audioPlayer.playCurrent(get(playerTime));
+            audioPlayer.setSeek(get(playerTime));
         }
 
         await reset();

--- a/src/lib/info/MetadataSection.svelte
+++ b/src/lib/info/MetadataSection.svelte
@@ -355,7 +355,6 @@
                     }),
                 ],
             };
-            // console.log("event: ", event);
 
             toImport = await invoke<ToImport>("write_metadatas", { event });
         } else if ($rightClickedTracks?.length) {

--- a/src/lib/info/TrackInfoPopup.svelte
+++ b/src/lib/info/TrackInfoPopup.svelte
@@ -140,7 +140,9 @@
     }
 
     function hasArtworkToSet() {
-        return artworkFileToSet || artworkToSetData;
+        return (
+            artworkFileToSet || artworkToSetData || isArtworkSet === "delete"
+        );
     }
 
     function onClose() {

--- a/src/lib/info/TrackInfoPopup.svelte
+++ b/src/lib/info/TrackInfoPopup.svelte
@@ -221,7 +221,6 @@
     // Shortcuts
     let modifier = $os === "macos" ? "cmd" : "ctrl";
     hotkeys(`${modifier}+enter`, "track-info", (event, handler) => {
-        console.log(`${modifier}+enter`, hasChanges);
         if (hasChanges) {
             metadata?.writeMetadata();
         }

--- a/src/lib/info/TrackInfoPopup.svelte
+++ b/src/lib/info/TrackInfoPopup.svelte
@@ -4,26 +4,14 @@
     import { open as fileOpen } from "@tauri-apps/plugin-shell";
 
     import hotkeys from "hotkeys-js";
-    import { cloneDeep, isEqual, uniqBy } from "lodash-es";
-    import type {
-        Album,
-        MetadataEntry,
-        Song,
-        TagType,
-        ToImport,
-    } from "src/App";
+    import type { Song } from "src/App";
     import { onDestroy, onMount } from "svelte";
     import toast from "svelte-french-toast";
     import tippy from "svelte-tippy";
     import { fade, fly } from "svelte/transition";
-    import { getMapForTagType } from "../../data/LabelMap";
-    import { readMappedMetadataFromSong } from "../../data/LibraryUtils";
     import { db } from "../../data/db";
     import {
-        current,
-        lastWrittenSongs,
         os,
-        playerTime,
         popupOpen,
         rightClickedTrack,
         rightClickedTracks,
@@ -31,14 +19,8 @@
     import { focusTrap } from "../../utils/FocusTrap";
     import "../tippy.css";
     import Input from "../ui/Input.svelte";
-    import { optionalTippy } from "../ui/TippyAction";
 
     import { convertFileSrc, invoke } from "@tauri-apps/api/core";
-    import {
-        ENCODINGS,
-        decodeLegacy,
-        encodeUtf8,
-    } from "../../utils/EncodingUtils";
     import {
         fetchAlbumArt,
         findCountryByArtist,
@@ -49,111 +31,15 @@
     import { Image } from "@tauri-apps/api/image";
     import { Buffer } from "buffer";
     import LL from "../../i18n/i18n-svelte";
-    import audioPlayer from "../player/AudioPlayer";
-    import { get } from "svelte/store";
+    import MetadataSection from "./MetadataSection.svelte";
     // optional
 
-    const ALBUM_FIELDS = [
-        "album",
-        "albumArtist",
-        "artist",
-        "date",
-        "genre",
-        "compilation",
-    ];
-
-    function onClose() {
-        $popupOpen = null;
-    }
-
-    function addDefaults(metadata: MetadataEntry[], format: TagType) {
-        // Map eg. 'TITLE' (FLAC/Vorbis) -> title (Musicat generic identifier)
-        const map = getMapForTagType(format, false);
-        // Add empty default fields
-        const defaults: MetadataEntry[] = [];
-        const others: MetadataEntry[] = [];
-        console.log("map", map);
-        if (!map) return { defaults, others };
-        for (const field of Object.entries(map)) {
-            // Check if this default field already exists in the file
-            const existingField = metadata?.find(
-                (m) => field[1] === m.genericId,
-            );
-
-            defaults.push({
-                id: field[0],
-                genericId: field[1],
-                value: existingField ? existingField.value : null,
-            });
-        }
-
-        for (const field of metadata) {
-            const inDefaults = defaults.find(
-                (t) => t.genericId === field.genericId,
-            );
-            if (!inDefaults) {
-                others.push({
-                    id: field.id,
-                    genericId: field.genericId,
-                    value: field.value,
-                });
-            }
-        }
-        return { defaults, others };
-    }
-
-    let isUnsupportedFormat = false;
-
-    function mergeDefault(
-        metadata: MetadataEntry[],
-        format: TagType,
-    ): MetadataEntry[] {
-        if (
-            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.codec ===
-            "WAV"
-        ) {
-            isUnsupportedFormat = true;
-            return []; // UNSUPPORTED FORMAT, for now...
-        }
-
-        console.log("adding defaults", metadata, format);
-        if (!format) return [];
-
-        isUnsupportedFormat = false;
-        const cloned = cloneDeep(metadata);
-        const { defaults, others } = addDefaults(cloned, format);
-        return uniqBy(
-            [...defaults, ...others.sort((a, b) => a.id.localeCompare(b.id))],
-            "id",
-        );
-    }
-
-    // console.log("track", ($rightClickedTrack || $rightClickedTracks[0]));
-    let metadata: { mappedMetadata: MetadataEntry[]; tagType: TagType } = {
-        mappedMetadata: [],
-        tagType: null,
-    };
-    let metadataFromFile: MetadataEntry[] = [];
-    // let metadata: MetadataEntry[] = cloneDeep(($rightClickedTrack || $rightClickedTracks[0]).metadata);
-
-    function getDurationText(durationInSeconds: number) {
-        return `${(~~(
-            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.duration /
-            60
-        ))
-            .toString()
-            .padStart(2, "0")}:${(~~(
-            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.duration %
-            60
-        ))
-            .toString()
-            .padStart(2, "0")}`;
-    }
-
     // The artwork for this track(s)
-    let artworkFormat;
     let artworkBuffer: Buffer;
+    let artworkFocused = false;
+    let artworkFormat;
     let artworkSrc;
+    let foundArtwork;
 
     // When scrolling through tracks, re-use artworks
     let previousArtworkFormat;
@@ -166,12 +52,23 @@
     let isArtworkSet: "delete" | "replace" | false = false;
     let artworkFileToSet = null;
 
-    let foundArtwork;
+    let unlisten;
 
-    $: hasChanges =
-        isArtworkSet || !isEqual(metadata?.mappedMetadata, metadataFromFile);
+    let previousAlbum = ($rightClickedTrack || $rightClickedTracks[0]).album;
 
-    let artworkFocused = false;
+    let metadata: MetadataSection;
+    let hasMetadataChanges: false;
+
+    $: hasChanges = !!isArtworkSet || hasMetadataChanges;
+
+    function completeMetadataEvent(event) {
+        event.artwork_file = artworkFileToSet ? artworkFileToSet : "";
+        event.artwork_data = artworkToSetData ?? [];
+        event.artwork_data_mime_type = artworkToSetFormat;
+        event.delete_artwork = isArtworkSet === "delete";
+
+        return event;
+    }
 
     async function getArtwork() {
         if ($rightClickedTrack === null && !$rightClickedTracks.length) {
@@ -190,7 +87,7 @@
                     `Error reading file ${path}. Check permissions, or if the file is used by another program.`,
                     { className: "app-toast" },
                 );
-                metadata = { mappedMetadata: [], tagType: null };
+                metadata.data = { mappedMetadata: [], tagType: null };
             }
 
             if (songWithArtwork?.artwork) {
@@ -228,171 +125,27 @@
         }
     }
 
-    /**
-     * Send an event to the backend to write the new metadata, overwriting any existing tags.
-     */
-    async function writeMetadata() {
-        let toImport: ToImport;
-        if ($rightClickedTrack) {
-            const toWrite = metadata?.mappedMetadata
-                .filter((m) => m.value !== null)
-                .map((t) => ({ id: t.id, value: t.value }));
-            console.log("Writing: ", toWrite);
-
-            const event = {
-                tracks: [
-                    {
-                        song_id: $rightClickedTrack.id,
-                        metadata: toWrite,
-                        tag_type: metadata.tagType,
-                        file_path: $rightClickedTrack.path,
-                        artwork_file: artworkFileToSet ? artworkFileToSet : "",
-                        artwork_data: artworkToSetData ?? [],
-                        artwork_data_mime_type: artworkToSetFormat,
-                        delete_artwork: isArtworkSet === "delete",
-                    },
-                ],
-            };
-            // console.log("event: ", event);
-
-            toImport = await invoke<ToImport>("write_metadatas", { event });
-        } else if ($rightClickedTracks?.length) {
-            console.log("Writing album");
-            toImport = await invoke<ToImport>("write_metadatas", {
-                event: {
-                    tracks: await Promise.all(
-                        $rightClickedTracks.map(async (track) => {
-                            const fileMetadata =
-                                await readMappedMetadataFromSong(track);
-                            return {
-                                song_id: track.id,
-                                metadata: [
-                                    ...fileMetadata?.mappedMetadata,
-                                    ...metadata?.mappedMetadata
-                                        .filter(
-                                            (m) =>
-                                                m.value !== null &&
-                                                ALBUM_FIELDS.includes(
-                                                    m.genericId,
-                                                ),
-                                        )
-                                        .map((t) => ({
-                                            id: t.id,
-                                            value: t.value,
-                                        })),
-                                ],
-                                tag_type: fileMetadata.tagType,
-                                file_path: track.path,
-                                artwork_file: artworkFileToSet
-                                    ? artworkFileToSet
-                                    : "",
-                                artwork_data: artworkToSetData ?? [],
-                                artwork_data_mime_type: artworkToSetFormat,
-                                delete_artwork: isArtworkSet === "delete",
-                            };
-                        }),
-                    ),
-                },
-            });
-        }
-        console.log($rightClickedTrack || $rightClickedTracks[0]);
-        console.log(toImport);
-        if (toImport) {
-            if (toImport.error) {
-                // Show error
-                toast.error(toImport.error);
-                // Roll back to current artwork
-                artworkToSetFormat = null;
-                artworkToSetSrc = null;
-                artworkToSetData = null;
-            } else {
-                await reImportTracks(toImport.songs);
-            }
-        }
-
-        if (toImport.albums.length) {
-            for (const album of toImport.albums) {
-                await reImportAlbum(album);
-            }
-        }
-
-        toast.success("Successfully written metadata!", {
-            position: "top-right",
-        });
-
-        $lastWrittenSongs = $rightClickedTrack
-            ? [$rightClickedTrack]
-            : $rightClickedTracks;
-
-        // If we changed the artwork tag, this offsets the audio data in the file,
-        // so we need to reload the song and seek to the current position
-        // (will cause audible gap)
-        const writtenTracks = $rightClickedTrack
-            ? [$rightClickedTrack]
-            : $rightClickedTracks;
-        if (
-            (artworkFileToSet || artworkToSetData) &&
-            writtenTracks.map((t) => t.id).includes($current.song.id)
-        ) {
-            audioPlayer.playCurrent(get(playerTime));
-        }
-
-        await reset();
+    function getDurationText(durationInSeconds: number) {
+        return `${(~~(
+            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.duration /
+            60
+        ))
+            .toString()
+            .padStart(2, "0")}:${(~~(
+            ($rightClickedTrack || $rightClickedTracks[0]).fileInfo.duration %
+            60
+        ))
+            .toString()
+            .padStart(2, "0")}`;
     }
 
-    async function reImportAlbum(album: Album) {
-        const existingAlbum = await db.albums.get(album.id);
-        if (existingAlbum) {
-            existingAlbum.tracksIds = [
-                ...existingAlbum.tracksIds,
-                ...album.tracksIds,
-            ];
-            await db.albums.put(existingAlbum);
-        }
+    function hasArtworkToSet() {
+        return artworkFileToSet || artworkToSetData;
     }
 
-    async function reImportTracks(songs: Song[]) {
-        await db.songs.bulkPut(songs);
+    function onClose() {
+        $popupOpen = null;
     }
-
-    /**
-     * @param {String} imageData a uint8 array
-     * @param {String} format the image format eg. image/jpeg
-     */
-    function setBlockPictureTag(imageData: string, format) {
-        const blockPicture = {
-            colour_depth: 24,
-            data: imageData,
-            description: "",
-            format,
-            height: 500,
-            indexed_color: 0,
-            type: "Cover (front)",
-            width: 500,
-        };
-        // metadata.push({
-        //     id: "METADATA_BLOCK_PICTURE",
-        //     value: blockPicture
-        // });
-    }
-
-    const imageUrlToBase64 = async (url): Promise<string> => {
-        const response = await fetch(url);
-        const blob = await response.blob();
-        return new Promise((onSuccess, onError) => {
-            try {
-                const reader = new FileReader();
-                reader.onload = function () {
-                    onSuccess(this.result as string);
-                };
-                reader.readAsDataURL(blob);
-            } catch (e) {
-                onError(e);
-            }
-        });
-    };
-
-    let unlisten;
 
     async function onImageClick(evt) {
         console.log("clicked", artworkFocused);
@@ -437,20 +190,20 @@
         }
     }
 
-    /**
-     * Grabs the existing tags from the file, and adds in the defaults for that file format
-     */
-    async function getMetadataFromFile(song: Song): Promise<MetadataEntry[]> {
-        // Get metadata from file
-        const { mappedMetadata, tagType } =
-            await readMappedMetadataFromSong(song);
-
-        const result = mergeDefault(mappedMetadata, tagType);
-        metadataFromFile = cloneDeep(result);
-        return result;
+    async function reset() {
+        updateArtwork();
+        previousAlbum = ($rightClickedTrack || $rightClickedTracks[0]).album;
+        originCountry =
+            ($rightClickedTrack || $rightClickedTracks[0]).originCountry || "";
+        originCountryEdited = originCountry;
+        metadata?.resetMetadata();
     }
 
-    let previousAlbum = ($rightClickedTrack || $rightClickedTracks[0]).album;
+    function rollbackArtwork() {
+        artworkToSetFormat = null;
+        artworkToSetSrc = null;
+        artworkToSetData = null;
+    }
 
     async function updateArtwork() {
         artworkFormat = null;
@@ -465,30 +218,12 @@
         await getArtwork();
     }
 
-    async function reset() {
-        updateArtwork();
-        containsError = null;
-        previousAlbum = ($rightClickedTrack || $rightClickedTracks[0]).album;
-        const { mappedMetadata, tagType } = await readMappedMetadataFromSong(
-            $rightClickedTrack || $rightClickedTracks[0],
-        );
-        metadata = {
-            mappedMetadata: mergeDefault(mappedMetadata, tagType),
-            tagType,
-        };
-        metadataFromFile = cloneDeep(metadata.mappedMetadata);
-        originCountry =
-            ($rightClickedTrack || $rightClickedTracks[0]).originCountry || "";
-        originCountryEdited = originCountry;
-        hasChanges = !isEqual(metadata?.mappedMetadata, metadataFromFile);
-        console.log("metadata", metadata);
-    }
-
     // Shortcuts
     let modifier = $os === "macos" ? "cmd" : "ctrl";
-    hotkeys(`${modifier}+enter`, "track-info", function (event, handler) {
+    hotkeys(`${modifier}+enter`, "track-info", (event, handler) => {
+        console.log(`${modifier}+enter`, hasChanges);
         if (hasChanges) {
-            writeMetadata();
+            metadata?.writeMetadata();
         }
     });
     hotkeys("esc", "track-info", () => {
@@ -499,185 +234,6 @@
         if ($rightClickedTrack || $rightClickedTracks[0]) {
             reset();
         }
-    }
-
-    let matchingArtists: string[] = [];
-
-    let distinctArtists;
-
-    let firstMatch: string = null;
-    $: firstMatchRemainder = firstMatch?.startsWith(artistInput)
-        ? firstMatch.substring(artistInput.length, firstMatch.length)
-        : "";
-    $: {
-        console.log(firstMatchRemainder);
-    }
-
-    $: artistInput =
-        metadata?.mappedMetadata?.find((m) => m.genericId === "compilation")
-            ?.value === "1" ||
-        metadata?.mappedMetadata?.find((m) => m.genericId === "albumArtist")
-            ?.value
-            ? ""
-            : metadata?.mappedMetadata?.find((m) => m.genericId === "artist")
-                  ?.value ?? "";
-
-    let artistInputField: HTMLInputElement;
-
-    function onArtistAutocompleteSelected() {
-        if (firstMatch?.length) {
-            console.log("firstMatch", firstMatch);
-            console.log("artistInput", artistInput);
-            const artistField = metadata?.mappedMetadata?.find(
-                (m) => m.genericId === "artist",
-            );
-            if (artistField) {
-                artistField.value = firstMatch;
-                artistInput = firstMatch;
-            }
-            metadata = metadata;
-            firstMatch = null;
-        }
-    }
-
-    async function onArtistUpdated(value) {
-        console.log("artist updated");
-        artistInput = value;
-        const artistField = metadata?.mappedMetadata?.find(
-            (m) => m.genericId === "artist",
-        );
-        if (artistField) {
-            artistField.value = artistInput;
-        }
-        metadata = metadata;
-        let matched = [];
-        const artist = value;
-        if (artist && artist.trim().length > 0) {
-            if (distinctArtists === undefined) {
-                distinctArtists = await db.songs.orderBy("artist").uniqueKeys();
-            }
-            distinctArtists.forEach((a) => {
-                if (a.toLowerCase().startsWith(artist.toLowerCase())) {
-                    matched.push(a);
-                }
-            });
-
-            firstMatch = matched.length && matched[0] ? matched[0] : null;
-        } else {
-            firstMatch = null;
-        }
-    }
-
-    const VALIDATION_STRINGS = {
-        "err:invalid-chars":
-            "Invalid characters in metadata tag (hidden/unicode characters?)",
-        "err:null-chars": "Hidden null characer",
-        "warn:custom-tag":
-            "Custom tags can't be parsed. If a custom tag can be a standard tag, use that instead.",
-    };
-
-    type ValidationErrors = "err:invalid-chars" | "err:null-chars";
-    type ValidationWarnings = "warn:custom-tag" | "warn:cyrillic-encoding";
-
-    type Validation = {
-        [key: string]: {
-            errors: ValidationErrors[];
-            warnings: ValidationWarnings[];
-        };
-    };
-
-    /**
-     * Some tags have a \u0000 character dangling at the end.
-     * This prevents the metadata from being read properly, so we can
-     * show a prompt to fix this with the user's permission.
-     */
-    let containsError: ValidationErrors = null;
-
-    function stripNonAsciiChars() {
-        metadata.mappedMetadata = metadata?.mappedMetadata.map((entry) => ({
-            ...entry,
-            id: entry.id?.replace(/(\u0000)/g, "") ?? entry.id,
-        }));
-        console.log("stripped ascii: ", metadata);
-        writeMetadata();
-    }
-
-    // Encodings
-    let selectedEncoding = "placeholder";
-
-    async function fixEncoding() {
-        for (let item of metadata?.mappedMetadata) {
-            if (!item?.value) continue;
-            const decoded = decodeLegacy(item.value, selectedEncoding);
-            const encoded = new TextDecoder().decode(encodeUtf8(decoded));
-            console.log("transformed: ", encoded);
-            item.value = encoded;
-            metadata = metadata;
-        }
-    }
-
-    /**
-     * A map of tag id <-> errors that apply to this tag
-     */
-    $: errors =
-        metadata?.mappedMetadata?.reduce((errors: Validation, currentTag) => {
-            containsError = null;
-            if (!errors[currentTag.id]) {
-                errors[currentTag.id] = {
-                    errors: [],
-                    warnings: [],
-                };
-            }
-            if (!errors[currentTag.id].errors) {
-                errors[currentTag.id].errors = [];
-            }
-            if (!errors[currentTag.id].warnings) {
-                errors[currentTag.id].warnings = [];
-            }
-
-            // Invalid characters - null unicode
-            if (currentTag.id.match(/[\u0000]+/g)) {
-                errors[currentTag.id].errors.push("err:null-chars");
-                containsError = "err:null-chars"; // We want to display a prompt
-            } // Invalid characters
-            else if (!currentTag.id.match(/^[a-zA-Z0-9©_:\-\.]+$/)) {
-                errors[currentTag.id].errors.push("err:invalid-chars");
-            }
-
-            // Custom tag - warning
-            if (currentTag.id.match(/^(TXXX:)/g)) {
-                errors[currentTag.id].warnings.push("warn:custom-tag");
-            }
-
-            // TODO Detect encodings
-            // Tried jschardet but it didn't give good results.
-            // Maybe scrap this entirely?
-
-            // const windows_encodings = ["windows-1251"];
-            // const encoding = jschardet.detect(currentTag.value || "", {
-            //     detectEncodings: ENCODINGS,
-            // });
-            // console.log('encoding detect', encoding);
-            // { encoding: "UTF-8", confidence: 0.9690625 }
-
-            // if (
-            //     windows_encodings.includes(encoding.encoding) &&
-            //     encoding.confidence > 0.5
-            // ) {
-            //     errors[currentTag.id].warnings.push("warn:cyrillic-encoding");
-            // }
-
-            console.log("hasErrors", hasError("err:null-chars"));
-            return errors;
-        }, {}) ?? {};
-
-    function hasError(errorType: ValidationErrors): boolean {
-        return (
-            errors &&
-            Object.values(errors).filter((err) =>
-                err.errors.includes(errorType),
-            ).length > 0
-        );
     }
 
     let originCountry =
@@ -834,22 +390,6 @@
         }
         isFetchingArtwork = false;
     }
-
-    function onTagLabelClick(tag: MetadataEntry) {
-        // Double-clicking on title populates the title from the filename
-        if (tag.genericId === "title") {
-            // Strip file extension from filename if any
-            const filename = $rightClickedTrack.file;
-            const extension = filename.split(".").pop();
-            const filenameWithoutExtension = filename.replace(
-                "." + extension,
-                "",
-            );
-            tag.value = filenameWithoutExtension;
-
-            metadata = metadata;
-        }
-    }
 </script>
 
 <container use:focusTrap>
@@ -861,7 +401,7 @@
         <div class="button-container">
             <ButtonWithIcon
                 disabled={!hasChanges}
-                onClick={writeMetadata}
+                onClick={() => metadata.writeMetadata()}
                 text={`Overwrite file${isMultiMode ? "s" : ""}`}
             />
             <small>Cmd + ENTER</small>
@@ -912,7 +452,7 @@
                             {#each $rightClickedTrack ? [$rightClickedTrack] : $rightClickedTracks as track}
                                 <tr>
                                     <td class="file-path">
-                                        <p
+                                        <div
                                             on:click={() =>
                                                 fileOpen(
                                                     track.path.replace(
@@ -921,25 +461,21 @@
                                                     ),
                                                 )}
                                         >
-                                            <span
-                                                ><Icon
+                                            <span>
+                                                <Icon
                                                     icon="bi:file-earmark-play"
                                                     size={12}
-                                                /></span
-                                            >
+                                                />
+                                            </span>
                                             {track.file}
-                                        </p></td
-                                    >
+                                        </div>
+                                    </td>
                                     <td>
-                                        <p>
-                                            {track.fileInfo.codec}
-                                        </p></td
-                                    >
+                                        <p>{track.fileInfo.codec}</p>
+                                    </td>
                                     <td>
-                                        <p>
-                                            {track.fileInfo.tagType}
-                                        </p></td
-                                    >
+                                        <p>{track.fileInfo.tagType}</p>
+                                    </td>
                                     <td>
                                         <p>
                                             {getDurationText(
@@ -948,10 +484,8 @@
                                         </p>
                                     </td>
                                     <td>
-                                        <p>
-                                            {track.fileInfo.sampleRate} hz
-                                        </p></td
-                                    >
+                                        <p>{track.fileInfo.sampleRate} hz</p>
+                                    </td>
                                     <td>
                                         {#if track.fileInfo.bitDepth}
                                             <p>
@@ -1104,167 +638,53 @@
         </section>
     </div>
     <div class="bottom">
-        <section class="metadata-section boxed">
-            <h5 class="section-title">
-                <Icon icon="fe:music" size={30} />{$LL.trackInfo.metadata()}
-            </h5>
-            {#if $rightClickedTrack || $rightClickedTracks[0]}
-                {#if isUnsupportedFormat}
-                    <p>
-                        {$LL.trackInfo.unsupportedFormat()}
-                    </p>
-                {:else}
-                    {#if containsError === "err:null-chars"}
-                        <div
-                            transition:fly={{ y: -20, duration: 100 }}
-                            class="error-prompt"
-                        >
-                            <Icon icon="ant-design:warning-outlined" />
-                            <p>
-                                {$LL.trackInfo.errors.nullChars()}
-                            </p>
-                            <button on:click={stripNonAsciiChars}
-                                >{$LL.trackInfo.fix()}</button
-                            >
-                        </div>
-                    {/if}
-                    <form>
-                        {#each metadata?.mappedMetadata?.filter((m) => $rightClickedTrack || ($rightClickedTracks.length && ALBUM_FIELDS.includes(m.genericId))) as tag, idx}
-                            {#if tag.genericId === "artist"}
-                                <div class="tag">
-                                    <p class="label">
-                                        {$LL.trackInfo.artist()}
-                                    </p>
-                                    <div class="line" />
-                                    <div
-                                        class="artist-input"
-                                        use:optionalTippy={{
-                                            content:
-                                                $LL.input.enterHintTooltip(),
-                                            placement: "bottom",
-                                            show:
-                                                firstMatch !== null &&
-                                                firstMatch.toLowerCase() !==
-                                                    artistInput?.toLowerCase() &&
-                                                artistInput?.length > 0,
-                                            showOnCreate: true,
-                                            trigger: "manual",
-                                        }}
-                                    >
-                                        <Input
-                                            small
-                                            value={artistInput}
-                                            autoCompleteValue={firstMatch}
-                                            onChange={onArtistUpdated}
-                                            onEnterPressed={onArtistAutocompleteSelected}
-                                            tabBehavesAsEnter
-                                            fullWidth
-                                        />
-                                    </div>
-                                </div>
-                            {:else}
-                                <div
-                                    use:optionalTippy={{
-                                        content: errors[tag.id]?.errors
-                                            .map((e) => VALIDATION_STRINGS[e])
-                                            .concat(
-                                                errors[tag.id]?.warnings.map(
-                                                    (e) =>
-                                                        VALIDATION_STRINGS[e],
-                                                ),
-                                            )
-                                            .join(","),
-                                        placement: "bottom",
-                                        theme: "error",
-                                        show:
-                                            errors[tag.id]?.errors.length > 0 ||
-                                            errors[tag.id]?.warnings.length > 0,
-                                    }}
-                                    class="tag
-                                        {errors[tag.id]?.warnings.length > 0
-                                        ? 'validation-warning'
-                                        : ''}
-                                         {errors[tag.id]?.errors.length > 0
-                                        ? 'validation-error'
-                                        : ''}"
-                                >
-                                    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-                                    <p
-                                        class="label"
-                                        class:unmapped={tag.genericId ===
-                                            undefined}
-                                        data-tag-id={tag.genericId || tag.id}
-                                        on:click={() => onTagLabelClick(tag)}
-                                        use:optionalTippy={{
-                                            content:
-                                                $LL.trackInfo.setTitleFromFileNameHint(),
-                                            show: tag.genericId === "title",
-                                            placement: "bottom",
-                                        }}
-                                    >
-                                        {tag.genericId ? tag.genericId : tag.id}
-                                    </p>
-                                    <div class="line" />
-                                    <Input
-                                        bind:value={tag.value}
-                                        fullWidth
-                                        small
-                                    />
-                                </div>
-                            {/if}
-                        {/each}
-                    </form>
-                    {#if metadata?.mappedMetadata?.length}
-                        <div class="tools">
-                            <h5 class="section-title">
-                                <Icon
-                                    icon="ri:tools-fill"
-                                />{$LL.trackInfo.tools()}
-                            </h5>
-                            <div class="tool">
-                                <div class="description">
-                                    <p>
-                                        {$LL.trackInfo.fixLegacyEncodings.title()}
-                                    </p>
-                                    <small
-                                        >{$LL.trackInfo.fixLegacyEncodings.body()}</small
-                                    >
-                                </div>
-                                <select bind:value={selectedEncoding}>
-                                    <option value="placeholder"
-                                        >{$LL.trackInfo.fixLegacyEncodings.hint()}</option
-                                    >
-                                    {#each ENCODINGS as encoding}
-                                        <option
-                                            value={encoding}
-                                            class="encoding"
-                                            on:click={() => {
-                                                selectedEncoding = encoding;
-                                            }}
-                                        >
-                                            <p>{encoding}</p>
-                                        </option>
-                                    {/each}
-                                </select>
-                                <ButtonWithIcon
-                                    text={$LL.trackInfo.fix()}
-                                    theme="transparent"
-                                    onClick={fixEncoding}
-                                    disabled={selectedEncoding ===
-                                        "placeholder"}
-                                />
-                            </div>
-                        </div>
-                    {/if}
-                {/if}
-            {:else}
-                <p>{$LL.trackInfo.noMetadata()}</p>
-            {/if}
-        </section>
+        <MetadataSection
+            bind:this={metadata}
+            bind:hasChanges={hasMetadataChanges}
+            completeEvent={completeMetadataEvent}
+            {hasArtworkToSet}
+            {reset}
+            {rollbackArtwork}
+        />
     </div>
 </container>
 
 <style lang="scss">
+    :global {
+        .info {
+            section.boxed {
+                border: 1px solid var(--popup-track-section-border);
+                border-radius: 5px;
+                min-width: 575px;
+                position: relative;
+                background-color: var(--popup-track-section-bg);
+            }
+
+            .section-title {
+                position: absolute;
+                border-radius: 4px;
+                max-height: 2em;
+                display: flex;
+                flex-direction: row;
+                gap: 5px;
+                align-items: center;
+                background-color: var(--popup-track-section-title-bg);
+                z-index: 11;
+                border: 1px solid rgb(from var(--inverse) r g b / 0.08);
+                top: -15px;
+                padding: 0 10px;
+                letter-spacing: 1px;
+                font-weight: 400;
+                left: 3em;
+                right: 0;
+                width: fit-content;
+                margin: 0.5em 0;
+                text-align: start;
+                color: var(--popup-track-section-title-text);
+                text-transform: uppercase;
+            }
+        }
+    }
     :global([data-tippy-root]) {
         white-space: pre-line;
     }
@@ -1515,38 +935,6 @@
         width: 100%;
     }
 
-    section.boxed {
-        border: 1px solid var(--popup-track-section-border);
-        border-radius: 5px;
-        min-width: 575px;
-        position: relative;
-        background-color: var(--popup-track-section-bg);
-    }
-
-    .section-title {
-        position: absolute;
-        border-radius: 4px;
-        max-height: 2em;
-        display: flex;
-        flex-direction: row;
-        gap: 5px;
-        align-items: center;
-        background-color: var(--popup-track-section-title-bg);
-        z-index: 11;
-        border: 1px solid rgb(from var(--inverse) r g b / 0.08);
-        top: -15px;
-        padding: 0 10px;
-        letter-spacing: 1px;
-        font-weight: 400;
-        left: 3em;
-        right: 0;
-        width: fit-content;
-        margin: 0.5em 0;
-        text-align: start;
-        color: var(--popup-track-section-title-text);
-        text-transform: uppercase;
-    }
-
     .file-section {
         padding: 4px;
 
@@ -1679,7 +1067,7 @@
                         display: flex;
                     }
 
-                    p {
+                    & > div {
                         overflow: hidden;
                         text-overflow: ellipsis;
                         white-space: nowrap;
@@ -1777,185 +1165,6 @@
             p {
                 margin-right: 1em;
             }
-        }
-    }
-
-    .metadata-section {
-        margin-top: 2em;
-        border-radius: 5px;
-        position: relative;
-        padding: 2em 1em;
-        color: var(--text);
-        position: relative;
-        width: 100%;
-        border: 1px solid
-            color-mix(in srgb, var(--background) 70%, var(--inverse));
-        background-color: color-mix(
-            in srgb,
-            var(--overlay-bg) 80%,
-            var(--inverse)
-        );
-
-        font-family:
-            system-ui,
-            -apple-system,
-            Avenir,
-            Helvetica,
-            Arial,
-            sans-serif;
-
-        .section-title {
-            color: var(--popup-track-metadata-title);
-            border: 1px solid
-                rgb(from var(--popup-track-metadata-title) r g b / 0.08);
-        }
-
-        > p {
-            opacity: 0.5;
-        }
-    }
-
-    form {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        column-gap: 3em;
-
-        @media only screen and (max-width: 700px) {
-            grid-template-columns: 1fr;
-            .tag {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                &:nth-child(odd) {
-                    justify-content: center;
-                }
-                &:nth-child(even) {
-                    justify-content: center;
-                }
-            }
-        }
-
-        @media only screen and (min-width: 701px) {
-            .tag {
-                display: flex;
-                align-items: center;
-                &:nth-child(odd) {
-                    justify-content: right;
-                }
-                &:nth-child(even) {
-                    justify-content: left;
-                    flex-direction: row-reverse;
-                }
-            }
-        }
-
-        .tag {
-            display: flex;
-            align-items: center;
-            position: relative;
-            margin: 1px 0;
-            > .label {
-                width: fit-content;
-                margin: 0;
-                font-size: 13px;
-                font-weight: 500;
-                color: var(--text);
-                font-family: monospace;
-                user-select: none;
-                cursor: default;
-                white-space: nowrap;
-                text-transform: uppercase;
-                border: 1px solid transparent;
-
-                &.unmapped {
-                    opacity: 0.5;
-                }
-                &[data-tag-id="title"] {
-                    &:hover {
-                        border: 1px solid
-                            color-mix(
-                                in srgb,
-                                var(--background) 60%,
-                                var(--inverse)
-                            );
-                        cursor: pointer;
-                    }
-                }
-            }
-
-            .line {
-                height: 1px;
-                background-color: color-mix(
-                    in srgb,
-                    var(--background) 60%,
-                    var(--inverse)
-                );
-                width: 40px;
-            }
-
-            &.validation-error {
-                border: 1px solid var(--popup-track-metadata-validation-error);
-            }
-
-            &.validation-warning {
-                border: 1px solid var(--popup-track-metadata-validation-warning);
-            }
-        }
-
-        .artist-input {
-            /* overflow: hidden; */
-        }
-    }
-
-    .tools {
-        border: 1px solid rgb(from var(--inverse) r g b / 0.08);
-        padding: 2em;
-        margin: 2em;
-        position: relative;
-
-        .section-title {
-            color: rgb(from var(--popup-track-section-title-text) r g b / 0.85);
-            border: transparent;
-        }
-
-        .tool {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            gap: 5px;
-            color: var(--text);
-            * {
-                color: var(--text);
-            }
-
-            .description {
-                text-align: left;
-                p {
-                    margin: 0;
-                }
-                small {
-                    opacity: 0.7;
-                    line-height: 0.5em;
-                }
-            }
-
-            select {
-                font-size: 20px;
-                padding: 0.2em 1em 0.3em 1em;
-            }
-        }
-    }
-
-    .error-prompt {
-        padding: 0.2em;
-        border-radius: 8px;
-        margin: 1em;
-        background-color: var(--popup-track-metadata-prompt-error);
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-        p {
-            margin: 0;
         }
     }
 </style>

--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -61,6 +61,7 @@ class AudioPlayer {
     artworkSrc: ArtworkSrc; // for media session (notifications)
     currentSong: Song;
     currentSongIdx: number;
+    seek: number = 0;
     isAlreadyLoadingSong = false; // for when the 'ended' event fires
     queue: Song[];
     shouldPlay = false; // Whether to play immediately after loading playlist
@@ -83,7 +84,9 @@ class AudioPlayer {
 
         seekTime.subscribe((time) => {
             // Tell Rust to play file with seek position
-            if (this.currentSong) this.playCurrent(time);
+            if (this.currentSong) {
+                this.setSeek(time);
+            }
         });
 
         this.setupMediaSession();
@@ -120,6 +123,8 @@ class AudioPlayer {
         });
 
         current.subscribe(async ({ song }) => {
+            this.seek = 0;
+
             if (song) {
                 this.currentSong = song;
             }
@@ -302,7 +307,7 @@ class AudioPlayer {
 
     playCurrent(seek: number = 0) {
         if (this.currentSong) {
-            this.playSong(this.currentSong, seek);
+            this.playSong(this.currentSong, seek || this.seek);
         } else {
             this.playSong(this.queue[this.currentSongIdx], seek);
         }
@@ -442,6 +447,16 @@ class AudioPlayer {
         }
     }
 
+    setSeek(seek: number) {
+        if (get(isPlaying)) {
+            this.playSong(this.currentSong, seek);
+        } else {
+            this.seek = seek;
+
+            playerTime.set(seek);
+        }
+    }
+
     async incrementPlayCounter(song: Song) {
         await db.songs.update(song, {
             playCount: song.playCount ? song.playCount + 1 : 1,
@@ -451,6 +466,8 @@ class AudioPlayer {
     // MEDIA
 
     async playSong(song: Song, position = 0, play = true, index = null) {
+        this.seek = 0;
+
         if (song) {
             if (get(isIAPlaying)) {
                 webAudioPlayer.pause();
@@ -539,17 +556,21 @@ class AudioPlayer {
     }
 
     async play(isResume: boolean) {
-        this.isStopped = false;
+        if (this.seek) {
+            this.playSong(this.currentSong, this.seek);
+        } else {
+            this.isStopped = false;
 
-        if (isResume) {
-            await invoke("decode_control", {
-                event: {
-                    decoding_active: true,
-                },
-            });
+            if (isResume) {
+                await invoke("decode_control", {
+                    event: {
+                        decoding_active: true,
+                    },
+                });
+            }
+
+            this.onPlay();
         }
-
-        this.onPlay();
     }
 
     async pause() {

--- a/src/lib/ui/ButtonWithIcon.svelte
+++ b/src/lib/ui/ButtonWithIcon.svelte
@@ -17,7 +17,9 @@
 
 <div
     on:click={() => {
-        if (isDestructive && !isConfirmingAction) {
+        if (disabled) {
+            return;
+        } else if (isDestructive && !isConfirmingAction) {
             isConfirmingAction = true;
         } else {
             onClick();


### PR DESCRIPTION
This PR includes several improvements for the track info popup:
- preserve unsupported tags
- show and update only supported tags
- filter displayed tags based on the selection (hide title when many songs are selected, ...)
- update album when metadata are updated
- split out the metadata section to its own component so it's easier to manage

And about the player on the sidebar:
- moving the handle of the seekbar doesn't automatically play the song
- update the infos when the metadata are updated