### PR TITLE
fix: issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
                 "vite": "^4.5.1",
                 "vite-bundle-analyzer": "^0.10.3",
                 "wavefile": "^11.0.0",
-                "wavesurfer.js": "^7.7.11",
+                "wavesurfer.js": "7.8.14",
                 "wikibase-sdk": "^9.2.4",
                 "wtf_wikipedia": "^10.3.2"
             }
@@ -5990,9 +5990,9 @@
             }
         },
         "node_modules/wavesurfer.js": {
-            "version": "7.8.15",
-            "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.8.15.tgz",
-            "integrity": "sha512-fWNnQt5BEGzuoJ7HRxfvpT1rOEI1AmCGPZ/+7QDkDVN/m2vIBeLVQ+5vENRMz1YwvZ/u1No0UV492/o8G++KXQ==",
+            "version": "7.8.14",
+            "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.8.14.tgz",
+            "integrity": "sha512-VwljnCf97GxpA/I6gKWVriBvGYEcwAsOCaLb3vauPE4Jm6rIl1C9zVZ2S0a9CCLjVzeG0UukHZxXSblQV8dReA==",
             "dev": true,
             "license": "BSD-3-Clause"
         },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "vite": "^4.5.1",
         "vite-bundle-analyzer": "^0.10.3",
         "wavefile": "^11.0.0",
-        "wavesurfer.js": "^7.7.11",
+        "wavesurfer.js": "7.8.14",
         "wikibase-sdk": "^9.2.4",
         "wtf_wikipedia": "^10.3.2"
     },

--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -126,11 +126,15 @@ class AudioPlayer {
         });
 
         current.subscribe(async ({ song, position }) => {
+            if (this.currentSong) {
+                if (this.currentSong !== song) {
+                    this.seek = 0;
+                }
+            } else {
+                this.seek = position || 0;
+            }
             if (song) {
                 this.currentSong = song;
-                this.seek = position || 0;
-            } else {
-                this.seek = 0;
             }
         });
 
@@ -504,7 +508,9 @@ class AudioPlayer {
             this.currentSong = song;
             console.log("play", play, this.shouldPlay);
             if (play) {
-                await this.play(false);
+                this.isStopped = false;
+                this.onPlay();
+
                 playerTime.set(position);
                 console.log(
                     "audioplayer::datachannel::",


### PR DESCRIPTION
This PR fixes 2 issues:
- getting the error `object has not yet decoded audio` when activating the waveform
  The error is due to `wavesurfer.setOptions({ duration: $current.song.fileInfo.duration });` which the version [`7.8.15`](https://github.com/katspaugh/wavesurfer.js/releases/tag/7.8.15) now allow. So I'm not sure why it was done before...
- after boot, the first song when paused and unpaused, it would go back to the position of when the app launched.