### PR TITLE
perf: reduce cpu usage

### DIFF
--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -313,6 +313,18 @@ class AudioPlayer {
             });
         }
 
+        listen(TauriEvent.WINDOW_BLUR, async () => {
+            if (this.webRTCReceiver) {
+                this.webRTCReceiver.shouldProcessData = false;
+            }
+        });
+
+        listen(TauriEvent.WINDOW_FOCUS, async () => {
+            if (this.webRTCReceiver) {
+                this.webRTCReceiver.shouldProcessData = true;
+            }
+        });
+
         appWindow.listen("toggle_play", async (event: any) => {
             console.log("toggle_play");
             this.togglePlay();

--- a/src/lib/player/WebRTCReceiver.ts
+++ b/src/lib/player/WebRTCReceiver.ts
@@ -11,6 +11,7 @@ export default class WebRTCReceiver {
     remoteConnection: RTCPeerConnection;
     dataChannel: RTCDataChannel;
     onSampleData: (samples: Uint8Array) => void;
+    shouldProcessData = true;
     shouldRestart = false;
     throughputSample: number[] = Array(THROUGHPUT_SAMPLE_SIZE).fill(0);
     lastSnapshotTime;
@@ -77,7 +78,7 @@ export default class WebRTCReceiver {
             // on event
             this.dataChannel.addEventListener("message", (event) => {
                 // console.log("webrtc::Data channel message", event);
-                if (event.data) {
+                if (this.shouldProcessData && event.data) {
                     this.onSampleData && this.onSampleData(event.data);
 
                     // Calculate throughput


### PR DESCRIPTION
This PR is a proof of concept, more for testing...

When the window lose the focus, it disables the processing of the data, so stop the oscilloscope.

When the window is still shown, there not much change.

But when hiding, the process `http://localhost` changes a bit:
- with the processing: 5%
- no processing: 3.5%

It's not much. But we should get more saving if the data weren't sent at all.

What are your results?