### PR TITLE
fix: remove menu

### DIFF
--- a/src/lib/library/CanvasLibrary.svelte
+++ b/src/lib/library/CanvasLibrary.svelte
@@ -389,6 +389,9 @@
     let ctx: CanvasRenderingContext2D;
     let dpr;
 
+    // if cursor over the library
+    let isOver = false;
+
     // drag-n-drop
     let isDraggingOver = false;
 
@@ -1238,6 +1241,16 @@
     });
 
     function onKeyDown(event) {
+        if (
+            isOver &&
+            event.keyCode === 65 &&
+            (($os === "macos" && event.metaKey) || event.ctrlKey)
+        ) {
+            event.preventDefault();
+
+            songsHighlighted = [...songs];
+        }
+
         if ($arrowFocus !== "library") return;
 
         if (event.keyCode === 16) {
@@ -1728,10 +1741,12 @@
             class:ready
             bind:this={scrollContainer}
             on:mouseenter={() => {
+                isOver = true;
                 isDraggingOver =
                     $selectedPlaylistFile && $draggedSongs?.length > 0;
             }}
             on:mouseleave={() => {
+                isOver = false;
                 isDraggingOver = false;
             }}
         >

--- a/src/lib/library/TrackMenu.svelte
+++ b/src/lib/library/TrackMenu.svelte
@@ -140,6 +140,7 @@
      */
     async function removeFromLibrary(songs: Song[]) {
         await deleteFromLibrary(songs);
+        await deleteTracksFromPlaylist(songs);
     }
 
     async function removeFromPlaylist(songs: Song[]) {
@@ -153,6 +154,7 @@
     async function removeFromSystem(songs: Song[]) {
         await deleteTracksFromFileSystem(songs);
         await deleteFromLibrary(songs);
+        await deleteTracksFromPlaylist(songs);
     }
 
     function searchArtistOnYouTube() {

--- a/src/lib/menu/MenuInput.svelte
+++ b/src/lib/menu/MenuInput.svelte
@@ -50,6 +50,7 @@
         <span>
             <Input
                 bind:value
+                disabled={isDisabled}
                 {onEnterPressed}
                 {onEscPressed}
                 fullWidth

--- a/src/lib/menu/MenuOption.svelte
+++ b/src/lib/menu/MenuOption.svelte
@@ -42,7 +42,7 @@
             : `background-color: ${$currentThemeObject["menu-item-highlight-bg"]};`
         : ""}
     on:click|stopPropagation={(e) => {
-        onClick && onClick();
+        !isDisabled && onClick && onClick();
     }}
 >
     <div class="bg" style={color ? `background-color: ${color}` : ""} />
@@ -140,7 +140,7 @@
             }
         }
         &.destructive {
-            &:hover {
+            &:hover:not(.disabled) {
                 background: var(--menu-item-destructive-hover-bg);
                 color: var(--menu-item-destructive-hover-text);
             }

--- a/src/lib/ui/Input.svelte
+++ b/src/lib/ui/Input.svelte
@@ -15,6 +15,7 @@
     export let padding = true;
     export let small = false;
     export let alt = false;
+    export let disabled = false;
 
     function onKeyDown(evt) {
         if (evt.keyCode === 13) {
@@ -68,6 +69,7 @@
         on:keydown={onKeyDown}
         spellcheck="false"
         autocomplete="off"
+        {disabled}
     />
 
     {#if autoCompleteValue && autoCompleteValue?.toLowerCase() !== value?.toLowerCase()}


### PR DESCRIPTION
Since removing songs can take some time, this PR adds:
- the loading spinner
- a description text
- disable the other items of the menu.

It also adds the `Ctrl+A` to select all the songs.