### PR TITLE
fix: album

### DIFF
--- a/src/data/LibraryUtils.ts
+++ b/src/data/LibraryUtils.ts
@@ -410,7 +410,7 @@ export async function deleteFromLibrary(tracks: Song[]) {
     });
 }
 
-function getAlbumId(track: Song) {
+export function getAlbumId(track: Song) {
     return md5(
         `${track.path.replace(`/${track.file}`, "")} - ${track.album}`.toLowerCase(),
     );

--- a/src/lib/albums/AlbumMenu.svelte
+++ b/src/lib/albums/AlbumMenu.svelte
@@ -197,7 +197,7 @@
         />
         <MenuDivider />
         <MenuOption text="⚡️ Enrich" isDisabled />
-        {#if song.artist}
+        {#if song?.artist}
             <MenuOption
                 isLoading={isLoading("country")}
                 onClick={fetchingOriginCountry}
@@ -235,7 +235,7 @@
             onClick={compose(searchArtworkOnBrave, song)}
             text="Search for artwork on Brave"
         />
-        {#if song.artist}
+        {#if song?.artist}
             <MenuDivider />
             <MenuOption
                 onClick={compose(searchArtistOnYouTube, song)}

--- a/src/lib/views/AlbumsView.svelte
+++ b/src/lib/views/AlbumsView.svelte
@@ -242,9 +242,11 @@
     async function onRightClick(e, album) {
         highlightedAlbum = album.id;
 
-        const songs = (await db.songs.bulkGet(album.tracksIds)).sort(
-            (a, b) => a.trackNumber - b.trackNumber,
-        );
+        const songs = (await db.songs.bulkGet(album.tracksIds))
+            // make sure that the song exist
+            .filter((song) => song)
+            // sort by track number
+            .sort((a, b) => a.trackNumber - b.trackNumber);
 
         albumMenu.open(album, songs, { x: e.clientX, y: e.clientY });
     }


### PR DESCRIPTION
This PR fixes:
- show context menu when the album does have any songs (due the next issue)
- correctly *update* album when its title have been changed

I had the issue where an album's title had a space at the end.
- `lofty` keeps the space
- `music-metadata` removes it