### PR TITLE
improve: album

### DIFF
--- a/src/lib/albums/AlbumDetails.svelte
+++ b/src/lib/albums/AlbumDetails.svelte
@@ -26,11 +26,7 @@
         var tracks = await db.songs
             .where("id")
             .anyOf($album.tracksIds)
-            .toArray();
-
-        tracks.sort((a, b) => {
-            return a.trackNumber - b.trackNumber;
-        });
+            .sortBy("trackNumber");
 
         canvasHeight = HEADER_HEIGHT + tracks.length * ROW_HEIGHT + 8;
 

--- a/src/lib/albums/AlbumDetails.svelte
+++ b/src/lib/albums/AlbumDetails.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { fade } from "svelte/transition";
-    import { db } from "../../data/db";
     import Icon from "../ui/Icon.svelte";
     import LL from "../../i18n/i18n-svelte";
     import CanvasLibrary from "../library/CanvasLibrary.svelte";
@@ -9,50 +8,36 @@
     import { albumColumnOrder, current, isPlaying } from "../../data/store";
     import { setQueue } from "../../data/storeHelper";
     import { HEADER_HEIGHT, ROW_HEIGHT } from "./util";
+    import type { Album, Song } from "../../App";
 
-    export let albumId: string; // id of the album to display
+    export let album: Album;
+    export let tracks: Song[];
 
-    let canvasHeight = HEADER_HEIGHT;
     let isHovered = false;
 
-    $: album = liveQuery(async () => {
-        return await db.albums.get(albumId);
-    });
-
     $: isPlayingCurrentAlbum =
-        $current.song?.album.toLowerCase() === $album?.title.toLowerCase();
+        $current.song?.album.toLowerCase() === album?.title.toLowerCase();
 
-    $: songs = liveQuery(async () => {
-        var tracks = await db.songs
-            .where("id")
-            .anyOf($album.tracksIds)
-            .sortBy("trackNumber");
-
-        canvasHeight = HEADER_HEIGHT + tracks.length * ROW_HEIGHT + 8;
-
-        return tracks;
-    });
+    $: canvasHeight = HEADER_HEIGHT + tracks.length * ROW_HEIGHT + 8;
 
     async function playPauseToggle() {
-        if ($current.song?.album.toLowerCase() === $album.title.toLowerCase()) {
+        if ($current.song?.album.toLowerCase() === album.title.toLowerCase()) {
             if ($isPlaying) {
                 audioPlayer.pause();
             } else {
                 audioPlayer.play(true);
             }
         } else {
-            const tracks = songs.getValue();
-
             setQueue(tracks, 0);
         }
     }
 </script>
 
-{#if $album}
+{#if album}
     <div
         in:fade={{ duration: 150 }}
         class="container"
-        class:hovered={isHovered && $album.artwork}
+        class:hovered={isHovered && album.artwork}
     >
         <div class="info-container">
             <div
@@ -72,12 +57,12 @@
                     async
                 />
                 <div class="artwork-frame">
-                    {#if $album.artwork}
+                    {#if album.artwork}
                         <img
                             alt="Artwork"
-                            type={$album.artwork.format}
+                            type={album.artwork.format}
                             class="artwork"
-                            src={$album.artwork.src}
+                            src={album.artwork.src}
                             loading="lazy"
                             async
                         />
@@ -116,17 +101,17 @@
                 </div>
             </div>
             <div class="info-frame">
-                <p class="title">{$album.displayTitle ?? $album.title}</p>
-                {#if $album.artist}
-                    <p class="artist">{$album.artist}</p>
+                <p class="title">{album.displayTitle ?? album.title}</p>
+                {#if album.artist}
+                    <p class="artist">{album.artist}</p>
                 {/if}
                 <div class="info">
-                    {#if $album.year > 0}
-                        <small>{$album.year}</small>
+                    {#if album.year > 0}
+                        <small>{album.year}</small>
                         <small>•</small>
                     {/if}
                     <small
-                        >{$album.tracksIds.length}
+                        >{album.tracksIds.length}
                         {$LL.albums.item.tracksLabel()}</small
                     >
                 </div>
@@ -135,7 +120,7 @@
         <div class="songs" style="height: {canvasHeight}px">
             <CanvasLibrary
                 bind:columnOrder={$albumColumnOrder}
-                allSongs={songs}
+                allSongs={liveQuery(() => tracks)}
             />
         </div>
     </div>

--- a/src/lib/albums/AlbumItem.svelte
+++ b/src/lib/albums/AlbumItem.svelte
@@ -25,12 +25,15 @@
         if (isPlayingCurrentAlbum) {
             audioPlayer.togglePlay();
         } else {
-            const tracks = await db.songs
-                .where("id")
-                .anyOf(album.tracksIds)
-                .sortBy("trackNumber");
+            const track = await db.songs.get(album.tracksIds[0]);
 
-            setQueue(tracks, 0);
+            audioPlayer.playSong(track);
+
+            const tracks = await db.songs.bulkGet(album.tracksIds.slice(1));
+
+            tracks.unshift(track);
+
+            setQueue(tracks, false);
         }
     }
 
@@ -62,10 +65,7 @@
             cancel = false;
 
             if (e.button === 0) {
-                const songs = await db.songs
-                    .where("id")
-                    .anyOf(album.tracksIds)
-                    .sortBy("trackNumber");
+                const songs = await db.songs.bulkGet(album.tracksIds);
 
                 if (cancel) {
                     resetDraggedSongs();

--- a/src/lib/albums/AlbumItem.svelte
+++ b/src/lib/albums/AlbumItem.svelte
@@ -28,11 +28,7 @@
             const tracks = await db.songs
                 .where("id")
                 .anyOf(album.tracksIds)
-                .toArray();
-
-            tracks.sort((a, b) => {
-                return a.trackNumber - b.trackNumber;
-            });
+                .sortBy("trackNumber");
 
             setQueue(tracks, 0);
         }
@@ -69,11 +65,7 @@
                 const songs = await db.songs
                     .where("id")
                     .anyOf(album.tracksIds)
-                    .toArray();
-
-                songs.sort((a, b) => {
-                    return a.trackNumber - b.trackNumber;
-                });
+                    .sortBy("trackNumber");
 
                 if (cancel) {
                     resetDraggedSongs();

--- a/src/lib/albums/util.ts
+++ b/src/lib/albums/util.ts
@@ -9,13 +9,15 @@ export async function getAlbumDetailsHeight(album: Album): Promise<number> {
     var tracks = await db.songs
         .where("id")
         .anyOf(album.tracksIds)
-        .toArray();
+        .sortBy("trackNumber");
 
-    tracks.sort((a, b) => {
-        return a.trackNumber - b.trackNumber;
-    });
-
-    const height = PADDING + 300 + HEADER_HEIGHT + tracks.length * ROW_HEIGHT + 8 + PADDING;
+    const height =
+        PADDING +
+        300 +
+        HEADER_HEIGHT +
+        tracks.length * ROW_HEIGHT +
+        8 +
+        PADDING;
 
     return height;
 }

--- a/src/lib/albums/util.ts
+++ b/src/lib/albums/util.ts
@@ -1,23 +1,7 @@
-import type { Album } from "../../App";
-import { db } from "../../data/db";
-
 export const HEADER_HEIGHT = 22;
 export const PADDING = 14;
 export const ROW_HEIGHT = 26;
 
-export async function getAlbumDetailsHeight(album: Album): Promise<number> {
-    var tracks = await db.songs
-        .where("id")
-        .anyOf(album.tracksIds)
-        .sortBy("trackNumber");
-
-    const height =
-        PADDING +
-        300 +
-        HEADER_HEIGHT +
-        tracks.length * ROW_HEIGHT +
-        8 +
-        PADDING;
-
-    return height;
+export async function getAlbumDetailsHeight(length: number): Promise<number> {
+    return PADDING + 300 + HEADER_HEIGHT + length * ROW_HEIGHT + 8 + PADDING;
 }

--- a/src/lib/library/CanvasLibrary.svelte
+++ b/src/lib/library/CanvasLibrary.svelte
@@ -963,11 +963,7 @@
             let tracks = await db.songs
                 .where("id")
                 .anyOf(album.tracksIds)
-                .toArray();
-
-            tracks.sort((a, b) => {
-                return a.trackNumber - b.trackNumber;
-            });
+                .sortBy("trackNumber");
 
             setQueue(tracks, song.viewModel.index);
         } else if ($uiView === "smart-query") {

--- a/src/lib/library/CanvasLibrary.svelte
+++ b/src/lib/library/CanvasLibrary.svelte
@@ -959,11 +959,7 @@
             }
 
             const album = albums[0];
-
-            let tracks = await db.songs
-                .where("id")
-                .anyOf(album.tracksIds)
-                .sortBy("trackNumber");
+            const tracks = await db.songs.bulkGet(album.tracksIds);
 
             setQueue(tracks, song.viewModel.index);
         } else if ($uiView === "smart-query") {

--- a/src/lib/views/AlbumsView.svelte
+++ b/src/lib/views/AlbumsView.svelte
@@ -266,10 +266,7 @@
             const oldRow = detailsAlbumRow;
 
             detailsAlbum = album;
-            detailsAlbumTracks = await db.songs
-                .where("id")
-                .anyOf(album.tracksIds)
-                .sortBy("trackNumber");
+            detailsAlbumTracks = await db.songs.bulkGet(album.tracksIds);
             detailsAlbumIndex = index;
             detailsAlbumRow = Math.floor(index / columnCount) + 2;
 

--- a/src/lib/views/AlbumsView.svelte
+++ b/src/lib/views/AlbumsView.svelte
@@ -36,6 +36,7 @@
     let detailsAlbumHeight = 0;
     let detailsAlbumIndex = -1;
     let detailsAlbumRow = -1;
+    let detailsAlbumTracks: Song[] = null;
     let highlightedAlbum;
     let isCurrentAlbumInView = false;
     let isInit = true;
@@ -254,6 +255,7 @@
     async function onLeftClick(e, album, index) {
         if (detailsAlbum == album) {
             detailsAlbum = null;
+            detailsAlbumTracks = null;
             detailsAlbumHeight = 0;
             detailsAlbumIndex = -1;
             detailsAlbumRow = -1;
@@ -262,11 +264,18 @@
             rowCount -= 1;
         } else {
             const oldRow = detailsAlbumRow;
-            detailsAlbumHeight = await getAlbumDetailsHeight(album);
 
             detailsAlbum = album;
+            detailsAlbumTracks = await db.songs
+                .where("id")
+                .anyOf(album.tracksIds)
+                .sortBy("trackNumber");
             detailsAlbumIndex = index;
             detailsAlbumRow = Math.floor(index / columnCount) + 2;
+
+            detailsAlbumHeight = await getAlbumDetailsHeight(
+                detailsAlbumTracks.length,
+            );
 
             if (oldRow >= 0) {
                 var sizes = [...itemSizes];
@@ -349,7 +358,10 @@
                     {#if index === 0 || index + 1 === rowCount}
                         <div></div>
                     {:else if detailsAlbumRow === index}
-                        <AlbumDetails albumId={detailsAlbum.id} />
+                        <AlbumDetails
+                            album={detailsAlbum}
+                            tracks={detailsAlbumTracks}
+                        />
                     {:else}
                         {#each Array(columnCount) as _, col (col)}
                             {@const albumIdx =

--- a/src/lib/views/WikiView.svelte
+++ b/src/lib/views/WikiView.svelte
@@ -267,10 +267,7 @@
                 audioPlayer.play(true);
             }
         } else if (album) {
-            let tracks = await db.songs
-                .where("id")
-                .anyOf(album.tracksIds)
-                .sortBy("trackNumber");
+            let tracks = await db.songs.bulkGet(album.tracksIds);
 
             setQueue(tracks, 0);
         }

--- a/src/lib/views/WikiView.svelte
+++ b/src/lib/views/WikiView.svelte
@@ -270,11 +270,7 @@
             let tracks = await db.songs
                 .where("id")
                 .anyOf(album.tracksIds)
-                .toArray();
-
-            tracks.sort((a, b) => {
-                return a.trackNumber - b.trackNumber;
-            });
+                .sortBy("trackNumber");
 
             setQueue(tracks, 0);
         }


### PR DESCRIPTION
This PR does:
- import the albums with their tracks kept in order
- play first song then load the remaining tracks to add them in the queue
- remove unnecessary load of album's tracks

From my testing:
- the import is a little bit slower (maybe `slice.iter().map(|(_, song)| (*song).clone()).collect()` can be improved)
- the first song loads, in average, in 10ms (from 1000ms)
- the tracks, in 15-500ms

Reference:
- #119

