### PR TITLE
improve: at end of queue, next song should be first song

### DIFF
--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -1238,7 +1238,7 @@ fn decode_loop(
                                         }
                                         info!("Buffer is now empty. Pausing stream...");
                                         guard.pause();
-                                        let _ = app_handle.emit("stopped", Some(0.0f64));
+                                        let _ = app_handle.emit("end_of_queue", Some(0.0f64));
                                     }
                                 }
                                 // Do not treat "end of stream" as a fatal error. It's the currently only way a

--- a/src/lib/player/AudioPlayer.ts
+++ b/src/lib/player/AudioPlayer.ts
@@ -278,10 +278,15 @@ class AudioPlayer {
             playerTime.set(event.payload);
         });
 
-        appWindow.listen("stopped", async (event: any) => {
+        appWindow.listen("end_of_queue", async (event: any) => {
             this.isStopped = true;
             playerTime.set(0);
             isPlaying.set(false);
+
+            this.currentSongIdx = -1;
+            this.currentSong = null;
+
+            current.set({ song: null, index: -1, position: 0 });
         });
 
         appWindow.listen("paused", async (event: any) => {
@@ -380,13 +385,17 @@ class AudioPlayer {
     }
 
     playNext() {
-        this.currentSongIdx++;
-        this.playSong(this.queue[this.currentSongIdx]);
+        if (this.currentSongIdx + 1 < this.queue?.length) {
+            this.currentSongIdx++;
+            this.playSong(this.queue[this.currentSongIdx]);
+        }
     }
 
     playPrevious() {
-        this.currentSongIdx--;
-        this.playSong(this.queue[this.currentSongIdx]);
+        if (this.currentSongIdx > 0) {
+            this.currentSongIdx--;
+            this.playSong(this.queue[this.currentSongIdx]);
+        }
     }
 
     restart() {}
@@ -654,7 +663,11 @@ class AudioPlayer {
             this.pause();
         } else {
             if (this.isStopped) {
-                this.playCurrent();
+                if (this.currentSong) {
+                    this.playCurrent();
+                } else {
+                    this.playNext();
+                }
             } else {
                 this.play(true);
             }

--- a/src/lib/sidebar/Sidebar.svelte
+++ b/src/lib/sidebar/Sidebar.svelte
@@ -267,6 +267,8 @@
 
             drawArtwork(previousSongIdx > current.index);
             previousSongIdx = current.index;
+        } else {
+            song = null;
         }
     });
 


### PR DESCRIPTION
This PR modifies the end of queue event as:
- reset the current song to null so no infos are displayed when the player is stopped
- the next song is the first song of the queue