### PR TITLE
fix: skip to next song on probe error

### DIFF
--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -480,7 +480,7 @@ fn decode_loop(
 
     // Loop here!
     loop {
-        info!("path_str is {:?}", path_str);
+        // info!("path_str is {:?}", path_str);
         path_str_clone = path_str.clone(); // Used for looping
         if let None = path_str {
             is_transition = false;

--- a/src-tauri/src/player.rs
+++ b/src-tauri/src/player.rs
@@ -480,7 +480,7 @@ fn decode_loop(
 
     // Loop here!
     loop {
-        // info!("path_str is {:?}", path_str);
+        info!("path_str is {:?}", path_str);
         path_str_clone = path_str.clone(); // Used for looping
         if let None = path_str {
             is_transition = false;
@@ -568,14 +568,49 @@ fn decode_loop(
             let probe_result = get_probe().format(&hint, mss, &format_opts, &metadata_opts);
             info!("probe format {:?}", probe_result.is_ok());
 
+            let song = crate::metadata::extract_metadata(
+                &Path::new(&p.clone().as_str()),
+                false,
+                false,
+                true,
+                &app_handle,
+            );
+
             if probe_result.is_err() {
                 error!("Error probing file: {}", probe_result.err().unwrap());
-                path_str = None;
-                let _ = reset_control_sender.send(true);
-                let _ = playback_state_sender.send(PlaybackState {
-                    is_playing: false,
-                    playback_speed,
-                });
+                is_transition = false; // Revert transition mode so that track/seek info is changed straight away
+
+                // Send song change event
+                if let Some(s) = &song {
+                    is_transition = false;
+                    let _ = app_handle.emit("song_change", Some(s));
+
+                    let mut next_track = None;
+                    while let Ok(value) = next_track_receiver.try_lock().unwrap().try_recv() {
+                        next_track.replace(value);
+                    }
+
+                    if let Some(request) = next_track {
+                        if let Some(path) = request.path.clone() {
+                            is_transition = true;
+                            info!("player: next track received! {:?}", request);
+                            path_str.replace(path);
+                            seek.replace(request.seek.unwrap());
+                            volume.replace(request.volume.unwrap());
+                            is_reset = false;
+                        } else {
+                            path_str = None;
+
+                            info!("player: nothing else in the queue");
+                            let _ = app_handle.emit("end_of_queue", Some(0.0f64));
+                        }
+                    } else {
+                        path_str = None;
+                    }
+                } else {
+                    path_str = None;
+                }
+
                 continue;
             }
 
@@ -771,14 +806,6 @@ fn decode_loop(
             previous_sample_rate = spec.rate;
             previous_channels = spec.channels.count();
             previous_audio_device_name = device_name.clone();
-
-            let song = crate::metadata::extract_metadata(
-                &Path::new(&p.clone().as_str()),
-                false,
-                false,
-                true,
-                &app_handle,
-            );
 
             if audio_output.is_none() || should_reset_audio {
                 info!("player: Resetting audio device");


### PR DESCRIPTION
I have an album which generates the error `ERROR Musicat::player:Error probing file: out of bounds` (it can be played on other players).
Currently, the player doesn't play the file and seems to be stuck.
This PR skips to the next song when such error occurs.

I've created an issue on Symphonia (https://github.com/pdeljanov/Symphonia/issues/354)